### PR TITLE
Delete runs-on centos

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,8 @@ on:
 name: Build binary
 
 jobs:
-  build_release_on_ubuntu:
-    name: Build binary on ubuntu
+  build:
+    name: Build binary
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -30,24 +30,4 @@ jobs:
               cd teeio-validator/build/
               cmake -DARCH=x64 -DTOOLCHAIN=GCC -DTARGET=Debug -DCRYPTO=mbedtls ..
               make -j
-
-  build_release_on_centos:
-    name: Build binary on centos
-    runs-on: centos-latest
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout Sources
-        uses: actions/checkout@v4
-
-      - name: Initialize and update submodules
-        run: git submodule update --init --recursive
-
-      - name: Prepare build directory
-        run: mkdir -p teeio-validator/build
-
-      - name: Build
-        run: |
-              cd teeio-validator/build/
-              cmake -DARCH=x64 -DTOOLCHAIN=GCC -DTARGET=Debug -DCRYPTO=mbedtls ..
-              make -j
+  


### PR DESCRIPTION
Fix #3 

Runner of centos is not supported in github.com.

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories