### PR TITLE
Dump key&iv when setting up ide_stream

### DIFF
--- a/teeio-validator/include/utils.h
+++ b/teeio-validator/include/utils.h
@@ -75,5 +75,6 @@ TEEIO_DEBUG_LEVEL get_ide_log_level_from_string(const char* debug_level);
 const char* get_ide_log_level_string(TEEIO_DEBUG_LEVEL debug_level);
 
 bool convert_hex_str_to_uint8(char* str, uint8_t* data8);
+void dump_hex_array(uint8_t* data, int size);
 
 #endif

--- a/teeio-validator/teeio_validator/test_case/ide_km_common.c
+++ b/teeio-validator/teeio_validator/test_case/ide_km_common.c
@@ -56,6 +56,14 @@ void set_host_ide_key_set(
 bool enable_ide_stream_in_ecap(int cfg_space_fd, uint32_t ecap_offset, TEST_IDE_TYPE ide_type, uint8_t ide_id, bool enable);
 void enable_host_ide_stream(int cfg_space_fd, uint32_t ecap_offset, TEST_IDE_TYPE ide_type, uint8_t ide_id, uint8_t *kcbar_addr, uint8_t rp_stream_index, bool enable);
 
+void dump_key_iv(pci_ide_km_aes_256_gcm_key_buffer_t* key_buffer)
+{
+  TEEIO_DEBUG((TEEIO_DEBUG_INFO, "Key:\n"));
+  dump_hex_array((uint8_t *)key_buffer->key, sizeof(key_buffer->key));
+  TEEIO_DEBUG((TEEIO_DEBUG_INFO, "IV:\n"));
+  dump_hex_array((uint8_t *)key_buffer->iv, sizeof(key_buffer->iv));
+}
+
 // program keys to device card and root port
 bool ide_km_key_prog(
     const void *pci_doe_context,
@@ -96,6 +104,9 @@ bool ide_km_key_prog(
 
     key_buffer.iv[0] = 0;
     key_buffer.iv[1] = PCIE_IDE_IV_INIT_VALUE;
+
+    dump_key_iv(&key_buffer);
+
     status = pci_ide_km_key_prog(pci_doe_context, spdm_context, session_id,
                                  stream_id,
                                  k_sets[ks] | directions[direction] | substreams[substream],

--- a/teeio-validator/teeio_validator/test_case/test_case_keyprog_1.c
+++ b/teeio-validator/teeio_validator/test_case/test_case_keyprog_1.c
@@ -37,6 +37,8 @@ void prime_host_ide_keys(
     const uint8_t direction,
     const uint8_t key_set_select);
 
+void dump_key_iv(pci_ide_km_aes_256_gcm_key_buffer_t* key_buffer);
+
 static const char* mKeyProgAssersion[] = {
     "ide_km_key_prog send receive_data",        // .0
     "sizeof(IdeKmMessage) == sizeof(KP_ACK)",   // .1
@@ -210,6 +212,8 @@ bool test_keyprog_1_run(void *test_context)
   uint8_t direction;
   uint8_t substream;
 
+  iv.bytes[0] = PCIE_IDE_IV_INIT_VALUE;
+
   uint8_t k_sets[] = {PCI_IDE_KM_KEY_SET_K0, PCI_IDE_KM_KEY_SET_K1};
   uint8_t directions[] = {PCI_IDE_KM_KEY_DIRECTION_RX, PCI_IDE_KM_KEY_DIRECTION_TX};
   uint8_t substreams[] = {PCI_IDE_KM_KEY_SUB_STREAM_PR, PCI_IDE_KM_KEY_SUB_STREAM_NPR, PCI_IDE_KM_KEY_SUB_STREAM_CPL};
@@ -225,6 +229,7 @@ bool test_keyprog_1_run(void *test_context)
   substream = PCIE_IDE_SUB_STREAM_PR;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|PR\n"));
   status = test_ide_km_key_prog_case1(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -242,6 +247,7 @@ bool test_keyprog_1_run(void *test_context)
   substream = PCIE_IDE_SUB_STREAM_NPR;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|NPR\n"));
   status = test_ide_km_key_prog_case1(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -259,6 +265,7 @@ bool test_keyprog_1_run(void *test_context)
   substream = PCIE_IDE_SUB_STREAM_CPL;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|CPL\n"));
   status = test_ide_km_key_prog_case1(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -282,6 +289,7 @@ bool test_keyprog_1_run(void *test_context)
   substream = PCIE_IDE_SUB_STREAM_PR;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|PR\n"));
   status = test_ide_km_key_prog_case1(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -299,6 +307,7 @@ bool test_keyprog_1_run(void *test_context)
   substream = PCIE_IDE_SUB_STREAM_NPR;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|NPR\n"));
   status = test_ide_km_key_prog_case1(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -316,6 +325,7 @@ bool test_keyprog_1_run(void *test_context)
   substream = PCIE_IDE_SUB_STREAM_CPL;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|CPL\n"));
   test_ide_km_key_prog_case1(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],

--- a/teeio-validator/teeio_validator/test_case/test_case_keyprog_2.c
+++ b/teeio-validator/teeio_validator/test_case/test_case_keyprog_2.c
@@ -21,6 +21,7 @@
 #include "utils.h"
 
 bool test_keyprog_setup_common(void *test_context);
+void dump_key_iv(pci_ide_km_aes_256_gcm_key_buffer_t* key_buffer);
 
 static const char* mKeyProgAssersion[] = {
     "ide_km_key_prog send receive_data",        // .0
@@ -158,6 +159,7 @@ bool test_keyprog_2_run(void *test_context)
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   request_size = sizeof(test_pci_ide_km_key_prog_t) - 4;
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|PR with request_size=%d\n", request_size));
   status = test_ide_km_key_prog_case2(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -171,6 +173,7 @@ bool test_keyprog_2_run(void *test_context)
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   request_size = sizeof(test_pci_ide_km_key_prog_t) - 8;
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|NPR with request_size=%d\n", request_size));
   status = test_ide_km_key_prog_case2(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -184,6 +187,7 @@ bool test_keyprog_2_run(void *test_context)
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   request_size = sizeof(test_pci_ide_km_key_prog_t) - 12;
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|CPL with request_size=%d\n", request_size));
   status = test_ide_km_key_prog_case2(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -197,6 +201,7 @@ bool test_keyprog_2_run(void *test_context)
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   request_size = sizeof(test_pci_ide_km_key_prog_t) - 16;
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|PR with request_size=%d\n", request_size));
   status = test_ide_km_key_prog_case2(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -210,6 +215,7 @@ bool test_keyprog_2_run(void *test_context)
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   request_size = sizeof(test_pci_ide_km_key_prog_t) - 20;
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|NPR with request_size=%d\n", request_size));
   test_ide_km_key_prog_case2(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -223,6 +229,7 @@ bool test_keyprog_2_run(void *test_context)
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   request_size = sizeof(test_pci_ide_km_key_prog_t) - 24;
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|CPL with request_size=%d\n", request_size));
   test_ide_km_key_prog_case2(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],

--- a/teeio-validator/teeio_validator/test_case/test_case_keyprog_3.c
+++ b/teeio-validator/teeio_validator/test_case/test_case_keyprog_3.c
@@ -22,6 +22,7 @@
 
 bool test_keyprog_setup_common(void *test_context);
 extern uint8_t m_keyprog_max_port;
+void dump_key_iv(pci_ide_km_aes_256_gcm_key_buffer_t* key_buffer);
 
 static const char* mKeyProgAssersion[] = {
     "ide_km_key_prog send receive_data",        // .0
@@ -179,6 +180,7 @@ bool test_keyprog_3_run(void *test_context)
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   port_index = m_keyprog_max_port + 1;
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|PR with port_index=%d(max=%d)\n", port_index, m_keyprog_max_port));
   status = test_ide_km_key_prog_case3(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -192,6 +194,7 @@ bool test_keyprog_3_run(void *test_context)
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   port_index = m_keyprog_max_port + 2;
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|NPR with port_index=%d(max=%d)\n", port_index, m_keyprog_max_port));
   status = test_ide_km_key_prog_case3(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -205,6 +208,7 @@ bool test_keyprog_3_run(void *test_context)
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   port_index = m_keyprog_max_port + 3;
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|CPL with port_index=%d(max=%d)\n", port_index, m_keyprog_max_port));
   status = test_ide_km_key_prog_case3(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -218,6 +222,7 @@ bool test_keyprog_3_run(void *test_context)
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   port_index = m_keyprog_max_port + 4;
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|PR with port_index=%d(max=%d)\n", port_index, m_keyprog_max_port));
   status = test_ide_km_key_prog_case3(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -231,6 +236,7 @@ bool test_keyprog_3_run(void *test_context)
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   port_index = m_keyprog_max_port + 5;
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|NPR with port_index=%d(max=%d)\n", port_index, m_keyprog_max_port));
   status = test_ide_km_key_prog_case3(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -244,6 +250,7 @@ bool test_keyprog_3_run(void *test_context)
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   port_index = m_keyprog_max_port + 6;
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|CPL with port_index=%d(max=%d)\n", port_index, m_keyprog_max_port));
   status = test_ide_km_key_prog_case3(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],

--- a/teeio-validator/teeio_validator/test_case/test_case_keyprog_4.c
+++ b/teeio-validator/teeio_validator/test_case/test_case_keyprog_4.c
@@ -21,6 +21,7 @@
 #include "teeio_debug.h"
 
 bool test_keyprog_setup_common(void *test_context);
+void dump_key_iv(pci_ide_km_aes_256_gcm_key_buffer_t* key_buffer);
 
 static const char* mKeyProgAssersion[] = {
     "ide_km_key_prog send receive_data",        // .0
@@ -158,6 +159,7 @@ bool test_keyprog_4_run(void *test_context)
   substream = PCIE_IDE_SUB_STREAM_PR;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|PR with substream=%d\n", substreams[substream]>>4));
   status = test_ide_km_key_prog_case4(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -170,6 +172,7 @@ bool test_keyprog_4_run(void *test_context)
   substream = PCIE_IDE_SUB_STREAM_NPR;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|NPR with substream=%d\n", substreams[substream]>>4));
   status = test_ide_km_key_prog_case4(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -182,6 +185,7 @@ bool test_keyprog_4_run(void *test_context)
   substream = PCIE_IDE_SUB_STREAM_CPL;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|CPL with substream=%d\n", substreams[substream]>>4));
   status = test_ide_km_key_prog_case4(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -194,6 +198,7 @@ bool test_keyprog_4_run(void *test_context)
   substream = PCIE_IDE_SUB_STREAM_PR;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|PR with substream=%d\n", substreams[substream]>>4));
   status = test_ide_km_key_prog_case4(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -206,6 +211,7 @@ bool test_keyprog_4_run(void *test_context)
   substream = PCIE_IDE_SUB_STREAM_NPR;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|NPR with substream=%d\n", substreams[substream]>>4));
   status = test_ide_km_key_prog_case4(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -218,6 +224,7 @@ bool test_keyprog_4_run(void *test_context)
   substream = PCIE_IDE_SUB_STREAM_CPL;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|CPL with substream=%d\n", substreams[substream]>>4));
   status = test_ide_km_key_prog_case4(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],

--- a/teeio-validator/teeio_validator/test_case/test_case_keyprog_5.c
+++ b/teeio-validator/teeio_validator/test_case/test_case_keyprog_5.c
@@ -21,6 +21,7 @@
 #include "teeio_debug.h"
 
 bool test_keyprog_setup_common(void *test_context);
+void dump_key_iv(pci_ide_km_aes_256_gcm_key_buffer_t* key_buffer);
 
 static const char* mKeyProgAssersion[] = {
     "ide_km_key_prog send receive_data",        // .0
@@ -159,6 +160,7 @@ bool test_keyprog_5_run(void *test_context)
   key_buffer.iv[1] += 1;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|PR with iv=%d\n", key_buffer.iv[1]));
   status = test_ide_km_key_prog_case5(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -172,6 +174,7 @@ bool test_keyprog_5_run(void *test_context)
   key_buffer.iv[1] += 1;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|NPR with iv=%d\n", key_buffer.iv[1]));
   status = test_ide_km_key_prog_case5(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -185,6 +188,7 @@ bool test_keyprog_5_run(void *test_context)
   key_buffer.iv[1] += 1;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|CPL with iv=%d\n", key_buffer.iv[1]));
   status = test_ide_km_key_prog_case5(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -198,6 +202,7 @@ bool test_keyprog_5_run(void *test_context)
   key_buffer.iv[1] += 1;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|PR with iv=%d\n", key_buffer.iv[1]));
   status = test_ide_km_key_prog_case5(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -211,6 +216,7 @@ bool test_keyprog_5_run(void *test_context)
   key_buffer.iv[1] += 1;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|NPR with iv=%d\n", key_buffer.iv[1]));
   status = test_ide_km_key_prog_case5(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -224,6 +230,7 @@ bool test_keyprog_5_run(void *test_context)
   key_buffer.iv[1] += 1;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|CPL with iv=%d\n", key_buffer.iv[1]));
   status = test_ide_km_key_prog_case5(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],

--- a/teeio-validator/teeio_validator/test_case/test_case_keyprog_6.c
+++ b/teeio-validator/teeio_validator/test_case/test_case_keyprog_6.c
@@ -21,6 +21,7 @@
 #include "teeio_debug.h"
 
 bool test_keyprog_setup_common(void *test_context);
+void dump_key_iv(pci_ide_km_aes_256_gcm_key_buffer_t* key_buffer);
 
 static const char* mKeyProgAssersion[] = {
     "ide_km_key_prog send receive_data",        // .0
@@ -159,6 +160,7 @@ bool test_keyprog_6_run(void *test_context)
   stream_id++;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|PR with stream_id=%d\n", stream_id));
   status = test_ide_km_key_prog_case6(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -172,6 +174,7 @@ bool test_keyprog_6_run(void *test_context)
   stream_id++;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|NPR with stream_id=%d\n", stream_id));
   status = test_ide_km_key_prog_case6(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -185,6 +188,7 @@ bool test_keyprog_6_run(void *test_context)
   stream_id++;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|CPL with stream_id=%d\n", stream_id));
   status = test_ide_km_key_prog_case6(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -198,6 +202,7 @@ bool test_keyprog_6_run(void *test_context)
   stream_id++;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|PR with stream_id=%d\n", stream_id));
   status = test_ide_km_key_prog_case6(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -211,6 +216,7 @@ bool test_keyprog_6_run(void *test_context)
   stream_id++;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|NPR with stream_id=%d\n", stream_id));
   status = test_ide_km_key_prog_case6(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
@@ -224,6 +230,7 @@ bool test_keyprog_6_run(void *test_context)
   stream_id++;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
+  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|CPL stream_id=%d\n", stream_id));
   status = test_ide_km_key_prog_case6(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],

--- a/teeio-validator/teeio_validator/utils.c
+++ b/teeio-validator/teeio_validator/utils.c
@@ -28,6 +28,7 @@
 extern FILE* m_logfile;
 
 #define MAX_TIME_STAMP_LENGTH 32
+#define COLUME_SIZE 16
 
 bool IsValidDecimalString(
     uint8_t *Decimal,
@@ -825,4 +826,43 @@ void log_file_close(){
     if(!m_logfile){
         fclose(m_logfile);
     }
+}
+
+static void dump_hex_array_to_str (
+  uint8_t  *array,
+  int  array_size,
+  char *str,
+  int str_size
+  )
+{
+  int index;
+  TEEIO_ASSERT(str_size >= array_size * 3);
+
+  for (index = 0; index < array_size; index++) {
+    if(index == array_size - 1) {
+      sprintf(str + index * 3, "%02x", array[index]);
+    } else {
+      sprintf(str + index * 3, "%02x ", array[index]);
+    }
+  }
+}
+
+void dump_hex_array(uint8_t* data, int size)
+{
+  int i = 0;
+  int count = size / COLUME_SIZE;
+  int left = size % COLUME_SIZE;
+  char one_line_buffer[COLUME_SIZE * 3] = {0};
+
+  for(i = 0; i < count; i++) {
+    memset(one_line_buffer, 0, sizeof(one_line_buffer));
+    dump_hex_array_to_str(data + i * COLUME_SIZE, COLUME_SIZE, one_line_buffer, COLUME_SIZE * 3);
+    TEEIO_DEBUG((TEEIO_DEBUG_INFO, "%04x: %s\n", i * COLUME_SIZE, one_line_buffer));
+  }
+
+  if(left != 0) {
+    memset(one_line_buffer, 0, sizeof(one_line_buffer));
+    dump_hex_array_to_str(data + i * COLUME_SIZE, left, one_line_buffer, COLUME_SIZE * 3);
+    TEEIO_DEBUG((TEEIO_DEBUG_INFO, "%04x: %s\n", i * COLUME_SIZE, one_line_buffer));
+  }
 }


### PR DESCRIPTION
Fix #56 

Key & IV are dump like below:
```
[2024-05-09 01:50:21.250][info] Key:
[2024-05-09 01:50:21.250][info] 0000: 05 11 ff 19 af 97 d0 49 3b 2a 2c a8 90 fe 18 32
[2024-05-09 01:50:21.250][info] 0010: be de e6 f9 dc 09 75 88 8e 75 8e 2a 10 fa a9 b4
[2024-05-09 01:50:21.250][info] IV:
[2024-05-09 01:50:21.250][info] 0000: 00 00 00 00 01 00 00 00
```