### PR TITLE
Refine doe log output

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -29,6 +29,8 @@ If you find anything missing or incorrect in the FAQ, feel free to create an iss
 
 - [How to enable spdm log?](#how-to-enable-spdm-log)
 
+- [How to enable doe log?](#how-to-enable-doe-log)
+
 ### What is TEE-IO Device Validation Utility?
 Intel TDX Connect adds “device” to TEE scope. “Device” need to follow standard protocols (SPDM, IDE, TDISP) to communicate with Intel Root Port and Intel TDX TSM. 
 TEE-IO Device Validation Utility is proposed to validate the interoperability of standard protocols (SPDM/IDE/TDISP) between the device and Intel component.
@@ -97,3 +99,6 @@ TEE-IO Device Validation Utility set debug_level in 2 ways: ide_test.ini and com
 
 ### How to enable spdm log?
 TEE-IO Device Validation Utility enables spdm log output by setting ide_test.ini. Refer to [Issue#57](https://github.com/intel/tee-io-validator/issues/57#issuecomment-2116503580)
+
+### How to enable doe log?
+TEE-IO Device Validation Utility enables doe log output by setting ide_test.ini. Refer to [Issue#94](https://github.com/intel/tee-io-validator/issues/94#issuecomment-2192973993)

--- a/doc/ide_test_ini.md
+++ b/doc/ide_test_ini.md
@@ -36,6 +36,7 @@ EntryName=EntryValue
 | libspdm_log|0/1 |0 | O | enable libspdm log if 1|
 | debug_level | verbose/info/warn/error | warn | O | debug level|
 | pcap_enable | 0/1 | 0 | O | enable pcap capture if 1|
+| doe_log|0/1 |0 | O | enable doe log if 1|
 
 [Ports]
 |Entry|Value|Default|Mandatory|Comment|

--- a/teeio-validator/include/ide_test.h
+++ b/teeio-validator/include/ide_test.h
@@ -154,6 +154,7 @@ typedef struct
   bool pci_log;
   uint32_t debug_level;
   bool libspdm_log;
+  bool doe_log;
   bool wo_tdisp;
   bool pcap_enable;
 } IDE_TEST_MAIN_CONFIG;

--- a/teeio-validator/teeio_validator/ide_test_ini.c
+++ b/teeio-validator/teeio_validator/ide_test_ini.c
@@ -2324,6 +2324,12 @@ void ParseMainSection(void *context, IDE_TEST_CONFIG *test_config)
     test_config->main_config.libspdm_log = data32 == 1;
   }
 
+  sprintf(entry_name, "doe_log");
+  if (GetDecimalUint32FromDataFile(context, (uint8_t *)section_name, (uint8_t *)entry_name, &data32))
+  {
+    test_config->main_config.doe_log = data32 == 1;
+  }
+
   sprintf(entry_name, "debug_level");
   if (!GetStringFromDataFile(context, (uint8_t *)section_name, (uint8_t *)entry_name, &entry_value))
   {
@@ -2450,6 +2456,7 @@ void dump_test_config(IDE_TEST_CONFIG *test_config)
   TEEIO_DEBUG((TEEIO_DEBUG_VERBOSE, "  pci_log=%s\n", main_config->pci_log == 0 ? "false":"true"));
   TEEIO_DEBUG((TEEIO_DEBUG_VERBOSE, "  debug_level=%s\n", get_ide_log_level_string(main_config->debug_level)));
   TEEIO_DEBUG((TEEIO_DEBUG_VERBOSE, "  libspdm_log=%s\n", main_config->libspdm_log == 0 ? "false":"true"));
+  TEEIO_DEBUG((TEEIO_DEBUG_VERBOSE, "  doe_log=%s\n", main_config->doe_log == 0 ? "false":"true"));
   TEEIO_DEBUG((TEEIO_DEBUG_VERBOSE, "  pcap_enable=%s\n", main_config->pcap_enable == 0 ? "false":"true"));
   TEEIO_DEBUG((TEEIO_DEBUG_VERBOSE, "\n"));
 

--- a/teeio-validator/teeio_validator/teeio_validator.c
+++ b/teeio-validator/teeio_validator/teeio_validator.c
@@ -26,6 +26,7 @@ bool g_run_test_suite = true;
 
 TEEIO_DEBUG_LEVEL g_debug_level = TEEIO_DEBUG_WARN;
 bool g_libspdm_log = false;
+bool g_doe_log = false;
 uint8_t g_scan_bus = INVALID_SCAN_BUS;
 
 FILE* m_logfile = NULL;
@@ -85,6 +86,7 @@ int main(int argc, char *argv[])
     }
     g_pci_log = ide_test_config.main_config.pci_log;
     g_libspdm_log = ide_test_config.main_config.libspdm_log;
+    g_doe_log = ide_test_config.main_config.doe_log;
 
     if(debug_level == TEEIO_DEBUG_NUM) {
         g_debug_level = ide_test_config.main_config.debug_level;

--- a/teeio-validator/tools/lside.c
+++ b/teeio-validator/tools/lside.c
@@ -28,6 +28,7 @@ bool g_run_test_suite = false;
 
 TEEIO_DEBUG_LEVEL g_debug_level = TEEIO_DEBUG_WARN;
 bool g_libspdm_log = false;
+bool g_doe_log = false;
 uint8_t g_scan_bus = INVALID_SCAN_BUS;
 FILE* m_logfile = NULL;
 

--- a/teeio-validator/tools/setide.c
+++ b/teeio-validator/tools/setide.c
@@ -28,6 +28,7 @@ bool g_run_test_suite = false;
 
 TEEIO_DEBUG_LEVEL g_debug_level = TEEIO_DEBUG_WARN;
 bool g_libspdm_log = false;
+bool g_doe_log = false;
 uint8_t g_scan_bus = INVALID_SCAN_BUS;
 FILE* m_logfile = NULL;
 


### PR DESCRIPTION
Fix #94 

There are 2 changes to refine doe log output
1. Add doe_log option to turn on/off doe log output.
2. Down-grade the log level of doe raw data output from info to verbose.