### PR TITLE
Update helperlib

### DIFF
--- a/teeio-validator/include/helperlib.h
+++ b/teeio-validator/include/helperlib.h
@@ -13,13 +13,24 @@
 #include "ide_test.h"
 #include "teeio_debug.h"
 
+// Define the macro to get the offset of a field in a struct
+#define OFFSET_OF(type, field) ((size_t) &(((type *)0)->field))
+
 void libspdm_sleep(uint64_t microseconds);
 
 // PCIE & MMIO helper APIs
 uint32_t device_pci_read_32 (uint32_t offset, int fp);
 void device_pci_write_32 (uint32_t offset, uint32_t data, int fp);
+
+uint16_t device_pci_read_16 (uint32_t offset, int fp);
+void device_pci_write_16 (uint32_t offset, uint16_t data, int fp);
+
 void mmio_write_reg32(void *const reg_ptr, const uint32_t reg_val);
 uint32_t mmio_read_reg32(void *reg_ptr);
+
+void mmio_write_reg64(void *const reg_ptr, const uint64_t reg_val);
+uint64_t mmio_read_reg64(void *reg_ptr);
+
 void reg_memcpy_dw(void *dst, uint64_t dst_bytes, void *src, uint64_t nbytes);
 bool parse_bdf_string(uint8_t* bdf, uint8_t* bus, uint8_t* device, uint8_t* function);
 bool is_valid_dev_func(uint8_t *df);
@@ -30,6 +41,7 @@ uint8_t calculate_checksum(uint8_t *table, size_t length);
 // ide_test.ini helper APIs
 bool is_valid_topology_type(uint8_t *type);
 IDE_TEST_TOPOLOGY_TYPE get_topology_type_from_name(uint8_t* name);
+
 bool is_valid_topology_connection(uint8_t *connection);
 IDE_TEST_CONNECT_TYPE get_connection_from_name(uint8_t* name);
 bool is_valid_port(IDE_TEST_PORTS_CONFIG *ports, uint8_t* port);

--- a/teeio-validator/library/helperlib/ide_ini_helper.c
+++ b/teeio-validator/library/helperlib/ide_ini_helper.c
@@ -22,6 +22,7 @@ extern const char *IDE_PORT_TYPE_NAMES[];
 extern const char *IDE_TEST_IDE_TYPE_NAMES[];
 extern const char *IDE_TEST_CONNECT_TYPE_NAMES[];
 extern const char *IDE_TEST_TOPOLOGY_TYPE_NAMES[];
+extern const char *IDE_TEST_CATEGORY_NAMES[];
 
 bool is_valid_topology_connection(uint8_t *connection)
 {

--- a/teeio-validator/library/helperlib/pcie_helper.c
+++ b/teeio-validator/library/helperlib/pcie_helper.c
@@ -158,7 +158,7 @@ uint32_t device_pci_read_32(uint32_t off_to_the_cfg_start, int fd){
     if(g_pci_log) {
         device = get_device_info_by_fd(fd);
         if(device) {
-          TEEIO_DEBUG((TEEIO_DEBUG_VERBOSE, "PCI_READ  : 0x%04x => 0x%08x (%s)\n", off_to_the_cfg_start, data, device->device_name));
+          TEEIO_DEBUG((TEEIO_DEBUG_VERBOSE, "PCI_READ32  : 0x%04x => 0x%08x (%s)\n", off_to_the_cfg_start, data, device->device_name));
         }
     }
 
@@ -176,9 +176,58 @@ void device_pci_write_32(uint32_t off_to_the_cfg_start, uint32_t value, int fd){
     if(g_pci_log) {
         device = get_device_info_by_fd(fd);
         if(device) {
-          TEEIO_DEBUG((TEEIO_DEBUG_VERBOSE, "PCI_WRITE : 0x%04x <= 0x%08x (%s)\n", off_to_the_cfg_start, value, device->device_name));
+          TEEIO_DEBUG((TEEIO_DEBUG_VERBOSE, "PCI_WRITE32 : 0x%04x <= 0x%08x (%s)\n", off_to_the_cfg_start, value, device->device_name));
         }
     }
+}
+
+uint16_t device_pci_read_16(uint32_t off_to_the_cfg_start, int fd){
+    uint16_t data;
+    IDE_TEST_DEVICES_INFO *device = NULL;
+
+    TEEIO_ASSERT (fd > 0);
+
+    lseek(fd,off_to_the_cfg_start,SEEK_SET);
+    read(fd, &data, 2);
+
+    if(g_pci_log) {
+        device = get_device_info_by_fd(fd);
+        if(device) {
+          TEEIO_DEBUG((TEEIO_DEBUG_VERBOSE, "PCI_READ16  : 0x%04x => 0x%04x (%s)\n", off_to_the_cfg_start, data, device->device_name));
+        }
+    }
+
+    return data;
+}
+
+void device_pci_write_16(uint32_t off_to_the_cfg_start, uint16_t value, int fd){
+    IDE_TEST_DEVICES_INFO *device = NULL;
+
+    TEEIO_ASSERT (fd > 0);
+
+    lseek(fd,off_to_the_cfg_start,SEEK_SET);
+    write(fd, &value, 2);
+
+    if(g_pci_log) {
+        device = get_device_info_by_fd(fd);
+        if(device) {
+          TEEIO_DEBUG((TEEIO_DEBUG_VERBOSE, "PCI_WRITE16 : 0x%04x <= 0x%04x (%s)\n", off_to_the_cfg_start, value, device->device_name));
+        }
+    }
+}
+
+void mmio_write_reg64(
+    void *const reg_ptr,
+    const uint64_t reg_val)
+{
+    *(volatile uint64_t *)reg_ptr = reg_val;
+}
+
+uint64_t mmio_read_reg64(void *reg_ptr)
+{
+    uint64_t data = 0;
+    data = *(volatile uint64_t *)reg_ptr;
+    return data;
 }
 
 void mmio_write_reg32(


### PR DESCRIPTION
Fix #104 

The major changes are:
1. Add device_pcie_read/write_16 and mmio_read/write 64. They are required in CXL.memcache.
2. OFFSET_OF is to get the offset of a field in a struct.