### PR TITLE
Update parse_keyp_table

### DIFF
--- a/teeio-validator/include/intel_keyp.h
+++ b/teeio-validator/include/intel_keyp.h
@@ -13,6 +13,12 @@
 
 // Below defitions are based on Root Complex IDE Programming Guide
 
+// Table 2-2. Protocol Type
+typedef enum {
+  INTEL_KEYP_PROTOCOL_TYPE_PCIE_CXLIO = 1,
+  INTEL_KEYP_PROTOCOL_TYPE_CXL_MEMCACHE = 2
+} INTEL_KEYP_PROTOCOL_TYPE;
+
 // Table 2-1. Key Programming Table Reporting Structure
 typedef struct {
   uint8_t   signature[4];

--- a/teeio-validator/include/pcie_ide_lib.h
+++ b/teeio-validator/include/pcie_ide_lib.h
@@ -170,7 +170,7 @@ get_stream_cfg_reg_block(
 /**
  * parse KEYP table
 */
-bool parse_keyp_table(ide_common_test_port_context_t *port_context);
+bool parse_keyp_table(ide_common_test_port_context_t *port_context, INTEL_KEYP_PROTOCOL_TYPE keyp_protocol);
 
 /**
  * map KCBAR into memory

--- a/teeio-validator/library/pcie_ide_lib/intel_rp_pcie.c
+++ b/teeio-validator/library/pcie_ide_lib/intel_rp_pcie.c
@@ -223,7 +223,7 @@ bool unmap_kcbar_addr(int kcbar_mem_fd, uint8_t* mapped_kcbar_addr)
 
 
 // Parse the KEYP table and map the kcbar address
-bool parse_keyp_table(ide_common_test_port_context_t *port_context)
+bool parse_keyp_table(ide_common_test_port_context_t *port_context, INTEL_KEYP_PROTOCOL_TYPE keyp_protocol)
 {
   const char *keyp_table = "/sys/firmware/acpi/tables/KEYP";
   const char KEYP_SIGNATURE[] = {'K', 'E', 'Y', 'P'};
@@ -278,7 +278,7 @@ bool parse_keyp_table(ide_common_test_port_context_t *port_context)
   {
     kcu = (INTEL_KEYP_KEY_CONFIGURATION_UNIT *)(buffer + offset);
     TEEIO_ASSERT(offset + kcu->Length <= size);
-    if (kcu->ProtocolType != 1)
+    if (kcu->ProtocolType != keyp_protocol)
     {
       offset += kcu->Length;
       continue;

--- a/teeio-validator/library/pcie_ide_lib/pcie_ide.c
+++ b/teeio-validator/library/pcie_ide_lib/pcie_ide.c
@@ -242,7 +242,7 @@ bool open_root_port(ide_common_test_port_context_t *port_context)
   port_context->ecap_offset = ecap_offset;
 
   // parse KEYP table and map the kcbar to user space
-  if (!parse_keyp_table(port_context))
+  if (!parse_keyp_table(port_context, INTEL_KEYP_PROTOCOL_TYPE_PCIE_CXLIO))
   {
     TEEIO_DEBUG((TEEIO_DEBUG_ERROR, "parse_keyp_table failed.\n"));
     goto InitRootPortFail;


### PR DESCRIPTION
Fix #106 

According to Root Complex IDE Programming Guide Table 2-2, there are 2 Protocol types in Key Configuration Unit Structure.