### PR TITLE
Refine the default test config functions

### DIFF
--- a/teeio-validator/library/pcie_ide_test_lib/test_config/test_config_default.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_config/test_config_default.c
@@ -23,7 +23,7 @@ bool test_config_support_common(void *test_context);
 // test selective_ide and link_ide with default config
 bool pcie_ide_test_config_default_enable_common(void *test_context)
 {
-  return true;
+  return test_config_enable_common(test_context);
 }
 
 bool pcie_ide_test_config_default_disable_common(void *test_context)
@@ -33,12 +33,12 @@ bool pcie_ide_test_config_default_disable_common(void *test_context)
 
 bool pcie_ide_test_config_default_support_common(void *test_context)
 {
-  return true;
+  return test_config_support_common(test_context);
 }
 
 bool pcie_ide_test_config_default_check_common(void *test_context)
 {
-  return true;
+  return test_config_check_common(test_context, "Check Common Assertion");
 }
 
 // test selective_and_link_ide with default config

--- a/teeio-validator/teeio_validator/ide_test.c
+++ b/teeio-validator/teeio_validator/ide_test.c
@@ -12,10 +12,6 @@
 #include "ide_test.h"
 #include "pcie_ide_test_lib.h"
 
-bool test_config_enable_common(void *test_context);
-bool test_config_check_common(void *test_context, const char* assertion_msg);
-bool test_config_support_common(void *test_context);
-
 extern const char *TEEIO_TEST_CATEGORY_NAMES[];
 
 void append_config_item(ide_run_test_config_item_t **head, ide_run_test_config_item_t* new)
@@ -718,10 +714,6 @@ static bool do_run_test_config_support(ide_run_test_config_t *run_test_config, I
 {
   bool ret = false;
 
-  if(!test_config_support_common(run_test_config->test_context)) {
-    return false;
-  }
-
   ide_run_test_config_item_t* config_item = run_test_config->config_item;
   do {
     TEEIO_ASSERT(config_item->support_func);
@@ -737,13 +729,9 @@ static bool do_run_test_config_enable(ide_run_test_config_t *run_test_config, ID
 {
   bool ret = false;
 
-  if(!test_config_enable_common(run_test_config->test_context)) {
-    return false;
-  }
-
   ide_run_test_config_item_t* config_item = run_test_config->config_item;
   do {
-    TEEIO_ASSERT(config_item->support_func);
+    TEEIO_ASSERT(config_item->enable_func);
     ret = config_item->enable_func(run_test_config->test_context);
 
     config_item = config_item->next;
@@ -756,13 +744,9 @@ static bool do_run_test_config_check(ide_run_test_config_t *run_test_config, IDE
 {
   bool ret = false;
 
-  if(!test_config_check_common(run_test_config->test_context, "Check Common Assertion")) {
-    return false;
-  }
-
   ide_run_test_config_item_t* config_item = run_test_config->config_item;
   do {
-    TEEIO_ASSERT(config_item->support_func);
+    TEEIO_ASSERT(config_item->check_func);
     ret = config_item->check_func(run_test_config->test_context);
 
     config_item = config_item->next;

--- a/teeio-validator/teeio_validator/ide_test_ini.c
+++ b/teeio-validator/teeio_validator/ide_test_ini.c
@@ -1883,14 +1883,8 @@ bool ParseConfigurationSection(void *context, IDE_TEST_CONFIG *test_config, int 
   }
   config.type = get_topology_type_from_name(entry_value);
 
-  // default config
-  sprintf(entry_name, "default");
-  if (GetDecimalUint32FromDataFile(context, (uint8_t *)section_name, (uint8_t *)entry_name, &data32))
-  {
-    if(data32 == 1) {
-      config.bit_map |= (uint32_t)(1<<IDE_TEST_CONFIGURATION_TYPE_DEFAULT);
-    }
-  }
+  // default config is always set
+  config.bit_map |= (uint32_t)(1<<IDE_TEST_CONFIGURATION_TYPE_DEFAULT);
 
   sprintf(entry_name, "switch");
   if (GetDecimalUint32FromDataFile(context, (uint8_t *)section_name, (uint8_t *)entry_name, &data32))


### PR DESCRIPTION
Each configuration has its own specific enable/disable/check/support funcs. The validator calls the configurations's funcs with chain, which means if there are 2 configurations, then validator calls the config's func one by one.

In a test case, there is default configuration funcs, such as checking if IDE Stream is supported. So in the previous implementation, these default funcs are:
 - test_config_support_common
 - test_config_enable_common
 - test_config_check_common

Actually they are type of IDE_TEST_CONFIGURATION_TYPE_DEFAULT. This patch calls the default type configuration funcs instead of the test_config_xxx_common funcs. This is to reduce the interfaces when a new test_category is introduced, such as CXL-IDE, TDISP, etc.