### PR TITLE
Refine the code of parsing Configuration_x section

### DIFF
--- a/doc/ide_test_ini.md
+++ b/doc/ide_test_ini.md
@@ -63,7 +63,8 @@ EntryName=EntryValue
 |Entry|Value|Default|Mandatory|Comment|
 |------|------|------|------|------|
 |type|string||M|available values are **selective_ide, link_ide, selective_and_link_ide**|
-|default|0/1|0|O|if default is set, then below fields are ignored, otherwise below fields are needed.|
+|category|string|pcie-ide|O|Test category. Available values are: **pcie-ide**|
+|default|0/1|1|O||
 |switch|0/1|0|O||
 |partial_header_encryption|0/1|0|O||
 |pcrc|0/1|0|O||

--- a/teeio-validator/include/ide_test.h
+++ b/teeio-validator/include/ide_test.h
@@ -189,6 +189,7 @@ typedef struct {
   int id;
   bool enabled;
   IDE_TEST_TOPOLOGY_TYPE type;
+  TEEIO_TEST_CATEGORY test_category;
   uint32_t bit_map;
 } IDE_TEST_CONFIGURATION;
 
@@ -403,7 +404,8 @@ typedef struct _ide_run_test_config_item_t ide_run_test_config_item_t;
 struct _ide_run_test_config_item_t {
   ide_run_test_config_item_t *next;
 
-  IDE_TEST_CONFIGURATION_TYPE type;
+  TEEIO_TEST_CATEGORY test_category;
+  uint8_t type;
 
   ide_common_test_config_enable_func_t enable_func;
   ide_common_test_config_disable_func_t disable_func;

--- a/teeio-validator/teeio_validator/ide_test.c
+++ b/teeio-validator/teeio_validator/ide_test.c
@@ -37,14 +37,15 @@ const char *m_ide_test_case_name[] = {
     "Test",
     NULL};
 
-const char *m_ide_test_configuration_name[] = {
-  "Default",
-  "Switch",
-  "PartialHeaderEncryption",
-  "PCRC",
-  "Aggregation",
-  "SelectiveIDEForConfiguration",
-  "TeeLimitedStream",
+// PCIE-IDE supported config items
+char* m_ide_test_configuration_name[] = {
+  "default",
+  "switch",
+  "partial_header_encryption",
+  "pcrc",
+  "aggregation",
+  "selective_ide_for_configuration",
+  "tee_limited_stream",
   NULL
 };
 
@@ -223,6 +224,18 @@ ide_test_case_funcs_t m_test_case_funcs[IDE_COMMON_TEST_CASE_NUM][MAX_CASE_ID] =
   }
 };
 
+int get_test_configuration_names(char*** config_names, TEEIO_TEST_CATEGORY test_category)
+{
+  if(test_category == TEEIO_TEST_CATEGORY_CXL_IDE) {
+    TEEIO_DEBUG((TEEIO_DEBUG_ERROR, "%s is not supported yet.\n", TEEIO_TEST_CATEGORY_NAMES[TEEIO_TEST_CATEGORY_CXL_IDE]));
+    return 0;
+  }
+
+  *config_names = m_ide_test_configuration_name;
+  return IDE_TEST_CONFIGURATION_TYPE_NUM;
+}
+
+
 ide_test_case_name_t* get_test_case_from_string(const char* test_case_name, int* index, TEEIO_TEST_CATEGORY test_category)
 {
   if(test_case_name == NULL) {
@@ -330,6 +343,7 @@ bool alloc_run_test_config_item(ide_run_test_config_t *rtc, int config_type, IDE
   TEEIO_ASSERT(config_item != NULL);
   memset(config_item, 0, sizeof(ide_run_test_config_item_t));
   config_item->type = config_type;
+  config_item->test_category = test_category;
 
   // assign the functions
   config_item->check_func = config_func->check;

--- a/teeio-validator/tools/ide_common.c
+++ b/teeio-validator/tools/ide_common.c
@@ -224,3 +224,8 @@ bool is_doe_error_asserted()
 void libspdm_sleep(uint64_t microseconds)
 {
 }
+
+int get_test_configuration_names(char*** config_names, TEEIO_TEST_CATEGORY test_category)
+{
+  return 0;
+}


### PR DESCRIPTION
Different test category may have different Configuration types. This patch add test_category in Configuration_x section and refine the code of parsing it.