### PR TITLE
Set stream_id to 0 in cxl-ide

### DIFF
--- a/teeio-validator/library/cxl_ide_test_lib/test_group/test_group.c
+++ b/teeio-validator/library/cxl_ide_test_lib/test_group/test_group.c
@@ -187,6 +187,9 @@ static bool common_test_group_setup(void *test_context)
     return false;
   }
 
+  // stream id in cxl-ide is always 0 according to cxl-spec
+  context->stream_id = 0;
+
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "test_group_setup done\n"));
 
   return true;


### PR DESCRIPTION
stream id in cxl-ide is always 0 according to cxl spec.