### PR TITLE
Dump Key/IV in PCIE-IDE and CXL-IDE

### DIFF
--- a/teeio-validator/include/helperlib.h
+++ b/teeio-validator/include/helperlib.h
@@ -83,4 +83,8 @@ bool get_uint32_array_from_string(uint32_t* array, uint32_t* array_size, const c
 // get the max value from uint32_t array
 uint32_t get_max_from_uint32_array(uint32_t* array, uint32_t size);
 
+// dump key/iv stored in IDE-KM KEY_PROG message.
+// Refer to PCIe Spec 6.1 Figure 6-57
+void dump_key_iv_in_key_prog(const uint32_t *key, int key_dw_size, const uint32_t *iv, int iv_dw_size);
+
 #endif

--- a/teeio-validator/library/pcie_ide_test_lib/include/pcie_ide_test_internal.h
+++ b/teeio-validator/library/pcie_ide_test_lib/include/pcie_ide_test_internal.h
@@ -95,4 +95,12 @@ bool test_pci_ide_km_key_set_stop(const void *pci_doe_context,
                             uint8_t stream_id, uint8_t key_sub_stream,
                             uint8_t port_index, const char* case_msg);
 
+/**
+ * Dump key_iv in rootport registers
+ * Refer to Root Complex IDE Key Configuration Unit Software Programing Guide Revision 1.01
+ *   Figure 2-3 Key Slot
+ *   Figure 2-4 IV Value Slot
+ */
+void pcie_dump_key_iv_in_rp(const char* direction, uint8_t *key, int key_size, uint8_t* iv, int iv_size);
+
 #endif

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_1.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_1.c
@@ -212,17 +212,18 @@ bool pcie_ide_test_keyprog_1_run(void *test_context)
   substream = PCIE_IDE_SUB_STREAM_PR;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|PR\n"));
   status = test_ide_km_key_prog_case1(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status);
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
   pass = pass & !LIBSPDM_STATUS_IS_ERROR(status);
 
   // program key in root port kcbar registers
   pcie_construct_rp_keys(key_buffer.key, sizeof(key_buffer.key), keys.bytes, sizeof(keys.bytes));
   slot_id = group_context->k_set[ks].slot_id[direction][substream];
   cfg_rootport_ide_keys(kcbar_ptr, group_context->rp_stream_index, direction, ks, substream, slot_id, &keys, &iv);
+  pcie_dump_key_iv_in_rp(direction == PCIE_IDE_STREAM_RX ? "TX" : "RX", (uint8_t *)keys.bytes, sizeof(keys.bytes), (uint8_t *)iv.bytes, sizeof(iv.bytes));
 
   // KS0|RX|NPR
   ks = PCIE_IDE_STREAM_KS0;
@@ -230,17 +231,18 @@ bool pcie_ide_test_keyprog_1_run(void *test_context)
   substream = PCIE_IDE_SUB_STREAM_NPR;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|NPR\n"));
   status = test_ide_km_key_prog_case1(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status);
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
   pass = pass & !LIBSPDM_STATUS_IS_ERROR(status);
 
   // program key in root port kcbar registers
   pcie_construct_rp_keys(key_buffer.key, sizeof(key_buffer.key), keys.bytes, sizeof(keys.bytes));
   slot_id = group_context->k_set[ks].slot_id[direction][substream];
   cfg_rootport_ide_keys(kcbar_ptr, group_context->rp_stream_index, direction, ks, substream, slot_id, &keys, &iv);
+  pcie_dump_key_iv_in_rp(direction == PCIE_IDE_STREAM_RX ? "TX" : "RX", (uint8_t *)keys.bytes, sizeof(keys.bytes), (uint8_t *)iv.bytes, sizeof(iv.bytes));
 
   // KS0|RX|CPL
   ks = PCIE_IDE_STREAM_KS0;
@@ -248,17 +250,18 @@ bool pcie_ide_test_keyprog_1_run(void *test_context)
   substream = PCIE_IDE_SUB_STREAM_CPL;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|CPL\n"));
   status = test_ide_km_key_prog_case1(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status);
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
   pass = pass & !LIBSPDM_STATUS_IS_ERROR(status);
 
   // program key in root port kcbar registers
   pcie_construct_rp_keys(key_buffer.key, sizeof(key_buffer.key), keys.bytes, sizeof(keys.bytes));
   slot_id = group_context->k_set[ks].slot_id[direction][substream];
   cfg_rootport_ide_keys(kcbar_ptr, group_context->rp_stream_index, direction, ks, substream, slot_id, &keys, &iv);
+  pcie_dump_key_iv_in_rp(direction == PCIE_IDE_STREAM_RX ? "TX" : "RX", (uint8_t *)keys.bytes, sizeof(keys.bytes), (uint8_t *)iv.bytes, sizeof(iv.bytes));
 
   prime_rp_ide_key_set(
       kcbar_ptr,
@@ -272,17 +275,18 @@ bool pcie_ide_test_keyprog_1_run(void *test_context)
   substream = PCIE_IDE_SUB_STREAM_PR;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|PR\n"));
   status = test_ide_km_key_prog_case1(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status);
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
   pass = pass & !LIBSPDM_STATUS_IS_ERROR(status);
 
   // program key in root port kcbar registers
   pcie_construct_rp_keys(key_buffer.key, sizeof(key_buffer.key), keys.bytes, sizeof(keys.bytes));
   slot_id = group_context->k_set[ks].slot_id[direction][substream];
   cfg_rootport_ide_keys(kcbar_ptr, group_context->rp_stream_index, direction, ks, substream, slot_id, &keys, &iv);
+  pcie_dump_key_iv_in_rp(direction == PCIE_IDE_STREAM_RX ? "TX" : "RX", (uint8_t *)keys.bytes, sizeof(keys.bytes), (uint8_t *)iv.bytes, sizeof(iv.bytes));
 
   // KS0|TX|NPR
   ks = PCIE_IDE_STREAM_KS0;
@@ -290,17 +294,18 @@ bool pcie_ide_test_keyprog_1_run(void *test_context)
   substream = PCIE_IDE_SUB_STREAM_NPR;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|NPR\n"));
   status = test_ide_km_key_prog_case1(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status);
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
   pass = pass & !LIBSPDM_STATUS_IS_ERROR(status);
 
   // program key in root port kcbar registers
   pcie_construct_rp_keys(key_buffer.key, sizeof(key_buffer.key), keys.bytes, sizeof(keys.bytes));
   slot_id = group_context->k_set[ks].slot_id[direction][substream];
   cfg_rootport_ide_keys(kcbar_ptr, group_context->rp_stream_index, direction, ks, substream, slot_id, &keys, &iv);
+  pcie_dump_key_iv_in_rp(direction == PCIE_IDE_STREAM_RX ? "TX" : "RX", (uint8_t *)keys.bytes, sizeof(keys.bytes), (uint8_t *)iv.bytes, sizeof(iv.bytes));
 
   // KS0|TX|CPL
   ks = PCIE_IDE_STREAM_KS0;
@@ -308,17 +313,18 @@ bool pcie_ide_test_keyprog_1_run(void *test_context)
   substream = PCIE_IDE_SUB_STREAM_CPL;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|CPL\n"));
   test_ide_km_key_prog_case1(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status);
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
   pass = pass & !LIBSPDM_STATUS_IS_ERROR(status);
 
   // program key in root port kcbar registers
   pcie_construct_rp_keys(key_buffer.key, sizeof(key_buffer.key), keys.bytes, sizeof(keys.bytes));
   slot_id = group_context->k_set[ks].slot_id[direction][substream];
   cfg_rootport_ide_keys(kcbar_ptr, group_context->rp_stream_index, direction, ks, substream, slot_id, &keys, &iv);
+  pcie_dump_key_iv_in_rp(direction == PCIE_IDE_STREAM_RX ? "TX" : "RX", (uint8_t *)keys.bytes, sizeof(keys.bytes), (uint8_t *)iv.bytes, sizeof(iv.bytes));
 
   prime_rp_ide_key_set(
       kcbar_ptr,

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_2.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_2.c
@@ -158,12 +158,12 @@ bool pcie_ide_test_keyprog_2_run(void *test_context)
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   request_size = sizeof(test_pci_ide_km_key_prog_t) - 4;
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|PR with request_size=%d\n", request_size));
   status = test_ide_km_key_prog_case2(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status, request_size);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|RX|NPR
   ks = PCIE_IDE_STREAM_KS0;
@@ -172,12 +172,12 @@ bool pcie_ide_test_keyprog_2_run(void *test_context)
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   request_size = sizeof(test_pci_ide_km_key_prog_t) - 8;
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|NPR with request_size=%d\n", request_size));
   status = test_ide_km_key_prog_case2(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status, request_size);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|RX|CPL
   ks = PCIE_IDE_STREAM_KS0;
@@ -186,12 +186,12 @@ bool pcie_ide_test_keyprog_2_run(void *test_context)
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   request_size = sizeof(test_pci_ide_km_key_prog_t) - 12;
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|CPL with request_size=%d\n", request_size));
   status = test_ide_km_key_prog_case2(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status, request_size);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|TX|PR
   ks = PCIE_IDE_STREAM_KS0;
@@ -200,12 +200,12 @@ bool pcie_ide_test_keyprog_2_run(void *test_context)
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   request_size = sizeof(test_pci_ide_km_key_prog_t) - 16;
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|PR with request_size=%d\n", request_size));
   status = test_ide_km_key_prog_case2(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status, request_size);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|TX|NPR
   ks = PCIE_IDE_STREAM_KS0;
@@ -214,12 +214,12 @@ bool pcie_ide_test_keyprog_2_run(void *test_context)
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   request_size = sizeof(test_pci_ide_km_key_prog_t) - 20;
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|NPR with request_size=%d\n", request_size));
   test_ide_km_key_prog_case2(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status, request_size);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|TX|CPL
   ks = PCIE_IDE_STREAM_KS0;
@@ -228,12 +228,12 @@ bool pcie_ide_test_keyprog_2_run(void *test_context)
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   request_size = sizeof(test_pci_ide_km_key_prog_t) - 24;
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|CPL with request_size=%d\n", request_size));
   test_ide_km_key_prog_case2(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status, request_size);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   case_context->result = pass ? IDE_COMMON_TEST_CASE_RESULT_SUCCESS : IDE_COMMON_TEST_CASE_RESULT_FAILED;
 

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_3.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_3.c
@@ -180,12 +180,12 @@ bool pcie_ide_test_keyprog_3_run(void *test_context)
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   port_index = m_keyprog_max_port + 1;
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|PR with port_index=%d(max=%d)\n", port_index, m_keyprog_max_port));
   status = test_ide_km_key_prog_case3(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 port_index, &key_buffer, &kp_ack_status);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|RX|NPR
   ks = PCIE_IDE_STREAM_KS0;
@@ -194,12 +194,12 @@ bool pcie_ide_test_keyprog_3_run(void *test_context)
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   port_index = m_keyprog_max_port + 2;
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|NPR with port_index=%d(max=%d)\n", port_index, m_keyprog_max_port));
   status = test_ide_km_key_prog_case3(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 port_index, &key_buffer, &kp_ack_status);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|RX|CPL
   ks = PCIE_IDE_STREAM_KS0;
@@ -208,12 +208,12 @@ bool pcie_ide_test_keyprog_3_run(void *test_context)
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   port_index = m_keyprog_max_port + 3;
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|CPL with port_index=%d(max=%d)\n", port_index, m_keyprog_max_port));
   status = test_ide_km_key_prog_case3(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 port_index, &key_buffer, &kp_ack_status);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|TX|PR
   ks = PCIE_IDE_STREAM_KS0;
@@ -222,12 +222,12 @@ bool pcie_ide_test_keyprog_3_run(void *test_context)
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   port_index = m_keyprog_max_port + 4;
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|PR with port_index=%d(max=%d)\n", port_index, m_keyprog_max_port));
   status = test_ide_km_key_prog_case3(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 port_index, &key_buffer, &kp_ack_status);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|TX|NPR
   ks = PCIE_IDE_STREAM_KS0;
@@ -236,12 +236,12 @@ bool pcie_ide_test_keyprog_3_run(void *test_context)
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   port_index = m_keyprog_max_port + 5;
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|NPR with port_index=%d(max=%d)\n", port_index, m_keyprog_max_port));
   status = test_ide_km_key_prog_case3(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 port_index, &key_buffer, &kp_ack_status);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|TX|CPL
   ks = PCIE_IDE_STREAM_KS0;
@@ -250,12 +250,12 @@ bool pcie_ide_test_keyprog_3_run(void *test_context)
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   port_index = m_keyprog_max_port + 6;
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|CPL with port_index=%d(max=%d)\n", port_index, m_keyprog_max_port));
   status = test_ide_km_key_prog_case3(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 port_index, &key_buffer, &kp_ack_status);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   case_context->result = pass ? IDE_COMMON_TEST_CASE_RESULT_SUCCESS : IDE_COMMON_TEST_CASE_RESULT_FAILED;
 

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_4.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_4.c
@@ -158,12 +158,12 @@ bool pcie_ide_test_keyprog_4_run(void *test_context)
   substream = PCIE_IDE_SUB_STREAM_PR;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|PR with substream=%d\n", substreams[substream]>>4));
   status = test_ide_km_key_prog_case4(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|RX|NPR
   ks = PCIE_IDE_STREAM_KS0;
@@ -171,12 +171,12 @@ bool pcie_ide_test_keyprog_4_run(void *test_context)
   substream = PCIE_IDE_SUB_STREAM_NPR;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|NPR with substream=%d\n", substreams[substream]>>4));
   status = test_ide_km_key_prog_case4(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|RX|CPL
   ks = PCIE_IDE_STREAM_KS0;
@@ -184,12 +184,12 @@ bool pcie_ide_test_keyprog_4_run(void *test_context)
   substream = PCIE_IDE_SUB_STREAM_CPL;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|CPL with substream=%d\n", substreams[substream]>>4));
   status = test_ide_km_key_prog_case4(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|TX|PR
   ks = PCIE_IDE_STREAM_KS0;
@@ -197,12 +197,12 @@ bool pcie_ide_test_keyprog_4_run(void *test_context)
   substream = PCIE_IDE_SUB_STREAM_PR;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|PR with substream=%d\n", substreams[substream]>>4));
   status = test_ide_km_key_prog_case4(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|TX|NPR
   ks = PCIE_IDE_STREAM_KS0;
@@ -210,12 +210,12 @@ bool pcie_ide_test_keyprog_4_run(void *test_context)
   substream = PCIE_IDE_SUB_STREAM_NPR;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|NPR with substream=%d\n", substreams[substream]>>4));
   status = test_ide_km_key_prog_case4(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|TX|CPL
   ks = PCIE_IDE_STREAM_KS0;
@@ -223,12 +223,12 @@ bool pcie_ide_test_keyprog_4_run(void *test_context)
   substream = PCIE_IDE_SUB_STREAM_CPL;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|CPL with substream=%d\n", substreams[substream]>>4));
   status = test_ide_km_key_prog_case4(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   case_context->result = pass ? IDE_COMMON_TEST_CASE_RESULT_SUCCESS : IDE_COMMON_TEST_CASE_RESULT_FAILED;
 

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_5.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_5.c
@@ -159,12 +159,12 @@ bool pcie_ide_test_keyprog_5_run(void *test_context)
   key_buffer.iv[1] += 1;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|PR with iv=%d\n", key_buffer.iv[1]));
   status = test_ide_km_key_prog_case5(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|RX|NPR
   ks = PCIE_IDE_STREAM_KS0;
@@ -173,12 +173,12 @@ bool pcie_ide_test_keyprog_5_run(void *test_context)
   key_buffer.iv[1] += 1;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|NPR with iv=%d\n", key_buffer.iv[1]));
   status = test_ide_km_key_prog_case5(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|RX|CPL
   ks = PCIE_IDE_STREAM_KS0;
@@ -187,12 +187,12 @@ bool pcie_ide_test_keyprog_5_run(void *test_context)
   key_buffer.iv[1] += 1;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|CPL with iv=%d\n", key_buffer.iv[1]));
   status = test_ide_km_key_prog_case5(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|TX|PR
   ks = PCIE_IDE_STREAM_KS0;
@@ -201,12 +201,12 @@ bool pcie_ide_test_keyprog_5_run(void *test_context)
   key_buffer.iv[1] += 1;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|PR with iv=%d\n", key_buffer.iv[1]));
   status = test_ide_km_key_prog_case5(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|TX|NPR
   ks = PCIE_IDE_STREAM_KS0;
@@ -215,12 +215,12 @@ bool pcie_ide_test_keyprog_5_run(void *test_context)
   key_buffer.iv[1] += 1;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|NPR with iv=%d\n", key_buffer.iv[1]));
   status = test_ide_km_key_prog_case5(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|TX|CPL
   ks = PCIE_IDE_STREAM_KS0;
@@ -229,12 +229,12 @@ bool pcie_ide_test_keyprog_5_run(void *test_context)
   key_buffer.iv[1] += 1;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|CPL with iv=%d\n", key_buffer.iv[1]));
   status = test_ide_km_key_prog_case5(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   case_context->result = pass ? IDE_COMMON_TEST_CASE_RESULT_SUCCESS : IDE_COMMON_TEST_CASE_RESULT_FAILED;
 

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_6.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_6.c
@@ -159,12 +159,12 @@ bool pcie_ide_test_keyprog_6_run(void *test_context)
   stream_id++;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|PR with stream_id=%d\n", stream_id));
   status = test_ide_km_key_prog_case6(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|RX|NPR
   ks = PCIE_IDE_STREAM_KS0;
@@ -173,12 +173,12 @@ bool pcie_ide_test_keyprog_6_run(void *test_context)
   stream_id++;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|NPR with stream_id=%d\n", stream_id));
   status = test_ide_km_key_prog_case6(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|RX|CPL
   ks = PCIE_IDE_STREAM_KS0;
@@ -187,12 +187,12 @@ bool pcie_ide_test_keyprog_6_run(void *test_context)
   stream_id++;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|CPL with stream_id=%d\n", stream_id));
   status = test_ide_km_key_prog_case6(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|TX|PR
   ks = PCIE_IDE_STREAM_KS0;
@@ -201,12 +201,12 @@ bool pcie_ide_test_keyprog_6_run(void *test_context)
   stream_id++;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|PR with stream_id=%d\n", stream_id));
   status = test_ide_km_key_prog_case6(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|TX|NPR
   ks = PCIE_IDE_STREAM_KS0;
@@ -215,12 +215,12 @@ bool pcie_ide_test_keyprog_6_run(void *test_context)
   stream_id++;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|NPR with stream_id=%d\n", stream_id));
   status = test_ide_km_key_prog_case6(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|TX|CPL
   ks = PCIE_IDE_STREAM_KS0;
@@ -229,12 +229,12 @@ bool pcie_ide_test_keyprog_6_run(void *test_context)
   stream_id++;
   result = libspdm_get_random_number(sizeof(key_buffer.key), (void *)key_buffer.key);
   TEEIO_ASSERT(result);
-  dump_key_iv(&key_buffer);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|CPL stream_id=%d\n", stream_id));
   status = test_ide_km_key_prog_case6(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status);
   pass = pass & status;
+  dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   case_context->result = pass ? IDE_COMMON_TEST_CASE_RESULT_SUCCESS : IDE_COMMON_TEST_CASE_RESULT_FAILED;
 


### PR DESCRIPTION
Fix #144 

```
[2024-10-10 00:48:37.122][info] key_prog RX - 00
[2024-10-10 00:48:37.122][info] Key (big-endian):
[2024-10-10 00:48:37.122][info] 0000: 6c 15 81 1a f7 c1 01 11 78 a6 95 72 28 e3 7e f3
[2024-10-10 00:48:37.122][info] 0010: 1c 06 99 4e 66 e5 da ff 56 50 ae f7 96 c2 bc 5b
[2024-10-10 00:48:37.122][info] IV (big-endian):
[2024-10-10 00:48:37.122][info] 0000: 00 00 00 00 00 00 00 00 00 00 00 01
[2024-10-10 00:48:37.665][info] key_prog TX - 00
[2024-10-10 00:48:37.665][info] Key (big-endian):
[2024-10-10 00:48:37.665][info] 0000: b3 f6 1f 6b 5f 7a ad 69 08 6a fc 75 2a 30 74 3a
[2024-10-10 00:48:37.665][info] 0010: 74 fa 75 9a 42 0f 8b 29 b3 bf b5 f2 5d 3c 4f b3
[2024-10-10 00:48:37.665][info] IV (big-endian):
[2024-10-10 00:48:37.665][info] 0000: 00 00 00 00 00 00 00 00 00 00 00 01
[2024-10-10 00:48:37.665][info] CXL IDE Key in rootport registers:
[2024-10-10 00:48:37.665][info]  Rx Encryption key 0: 0x69ad7a5f6b1ff6b3
[2024-10-10 00:48:37.665][info]  Rx Encryption key 1: 0x3a74302a75fc6a08
[2024-10-10 00:48:37.665][info]  Rx Encryption key 2: 0x298b0f429a75fa74
[2024-10-10 00:48:37.665][info]  Rx Encryption key 3: 0xb34f3c5df2b5bfb3
[2024-10-10 00:48:37.665][info] CXL IDE IV in rootport registers:
[2024-10-10 00:48:37.665][info]   Rx IF: 0x0000000000000001
[2024-10-10 00:48:37.665][info] CXL IDE Key in rootport registers:
[2024-10-10 00:48:37.665][info]  Tx Encryption key 0: 0x1101c1f71a81156c
[2024-10-10 00:48:37.665][info]  Tx Encryption key 1: 0xf37ee3287295a678
[2024-10-10 00:48:37.665][info]  Tx Encryption key 2: 0xffdae5664e99061c
[2024-10-10 00:48:37.665][info]  Tx Encryption key 3: 0x5bbcc296f7ae5056
[2024-10-10 00:48:37.665][info] CXL IDE IV in rootport registers:
[2024-10-10 00:48:37.665][info]   Tx IF: 0x0000000000000001
```