### PR TITLE
Generate CXL IDE Key based on ide_key_generation_capable

### DIFF
--- a/teeio-validator/include/helperlib.h
+++ b/teeio-validator/include/helperlib.h
@@ -62,6 +62,7 @@ IDE_PORT* get_port_from_switch_by_id(IDE_SWITCH *sw, int port_id);
 
 bool pcie_construct_rp_keys(void* key_prog_keys, int key_prog_keys_size, void* rp_keys, int rp_keys_size);
 bool cxl_construct_rp_keys(void* key_prog_keys, int key_prog_keys_size, void* rp_keys, int rp_keys_size);
+bool cxl_construct_rp_iv(uint32_t* key_prog_iv, int key_prog_iv_size, uint32_t* rp_iv, int rp_iv_size);
 bool IsValidDecimalString(uint8_t *Decimal, uint32_t Length);
 bool IsValidDigitalChar(uint8_t DigitalChar, bool IncludeHex);
 bool IsValidHexString(uint8_t *Hex, uint32_t Length);

--- a/teeio-validator/library/helperlib/utils.c
+++ b/teeio-validator/library/helperlib/utils.c
@@ -132,6 +132,22 @@ bool cxl_construct_rp_keys(void* key_prog_keys, int key_prog_keys_size, void* rp
 }
 
 /**
+ * Refer to doc/key_byte_order.md
+ *  ## CXL IDE_KM KEY_PROG message
+ *  ## Intel Root Complex CXL Key/IV register
+ */
+bool cxl_construct_rp_iv(uint32_t* key_prog_iv, int key_prog_iv_size, uint32_t* rp_iv, int rp_iv_size)
+{
+  TEEIO_ASSERT(key_prog_iv_size == 3 * 4);
+  TEEIO_ASSERT(rp_iv_size == 2 * 4);
+
+  *rp_iv = *(key_prog_iv + 2);
+  *(rp_iv + 1) = *(key_prog_iv + 1);
+
+  return true;
+}
+
+/**
   Return if the decimal string is valid.
 
   @param[in] Decimal The decimal string to be checked.


### PR DESCRIPTION
Fix #132 
Based on CXL Spec 3.1 (Section 11.4.5 & 11.4.7), CXL IDE Key is generated in 2 ways:
1. Device generates the Key/IV by receiving the "Get Key Message"
2. Rootport generates the Key.