### PR TITLE
Fix error when do PCIE-IDE KeyRefresh

### DIFF
--- a/teeio-validator/library/pcie_ide_lib/pcie_ide.c
+++ b/teeio-validator/library/pcie_ide_lib/pcie_ide.c
@@ -336,7 +336,7 @@ bool pcie_ide_alloc_slot_ids(ide_common_test_port_context_t* port_context, uint8
     key_iv_slot_usage_map = (1 << keyset.pr/3) | key_iv_slot_usage_map;
   }
 
-  TEEIO_DEBUG((TEEIO_DEBUG_INFO, "key/iv slot usage: key_iv_slot_usage_map=%08x\n", key_iv_slot_usage_map));
+  TEEIO_DEBUG((TEEIO_DEBUG_INFO, "key/iv slot usage: key_iv_slot_usage_map=%02x\n", key_iv_slot_usage_map));
   for(i = 0; i < num_key_iv_slots / 3; i++) {
     uint8_t key_iv_slot = (key_iv_slot_usage_map >> i) & 0x1;
     // 0 indicates the slots are free, 1 indicates the slots are occupied.

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/ide_km_common.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/ide_km_common.c
@@ -132,7 +132,7 @@ bool ide_km_key_prog(
 
     // program key in root port kcbar registers
     pcie_construct_rp_keys(key_buffer.key, sizeof(key_buffer.key), keys.bytes, sizeof(keys.bytes));
-    slot_id = k_set[ks].slot_id[direction][substream];
+    slot_id = k_set->slot_id[direction][substream];
     cfg_rootport_ide_keys(kcbar_ptr, rp_stream_index, direction, ks, substream, slot_id, &keys, &iv);
     TEEIO_DEBUG((TEEIO_DEBUG_INFO, "rp key_prog %s|%s|%s - @key/iv slot[%02x]\n", k_set_names[ks], direction_names[direction], substream_names[substream], slot_id));
     pcie_dump_key_iv_in_rp(direction == PCIE_IDE_STREAM_RX ? "TX" : "RX", (uint8_t *)keys.bytes, sizeof(keys.bytes), (uint8_t *)iv.bytes, sizeof(iv.bytes));
@@ -459,10 +459,6 @@ bool ide_key_switch_to(void* doe_context, void* spdm_context,
     // step 2: program keys in rp/dev in RX/TX direction
 
   // Before programming keys, we shall find empty key/iv slot
-  if(!pcie_ide_alloc_slot_ids(upper_port, rp_stream_index, k_set)) {
-    return false;
-  }
-
   while(true) {
     if(pcie_ide_alloc_slot_ids(upper_port, rp_stream_index, k_set)) {
       break;

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_full_keyrefresh.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_full_keyrefresh.c
@@ -123,7 +123,7 @@ bool pcie_ide_test_full_keyrefresh_run(void *test_context)
       res = ide_key_switch_to(doe_context, spdm_context, &session_id,
                               upper_port->mapped_kcbar_addr, stream_id,
                               group_context->k_set, group_context->rp_stream_index,
-                              0, group_context->top->type, upper_port, lower_port, 0, false);
+                              0, group_context->top->type, upper_port, lower_port, mKeySet, false);
       if(!res) {
         break;
       }


### PR DESCRIPTION
Fix #158

Have been verified with 4 cards concurrently.
```
Allocate kv/iv slot for rootport_4. Its rp_stream_index is stream_d
Walk thru Rootport KCBar stream_x to collect the used key/iv slots.
num_stream_supported=4, num_key_iv_slots=15
stream_a:
    stream_control: enable=1, stream_id=1
    tx_control    : key_set_select=1, prime_key_set_0=0, prime_key_set_1=0
    keyset_0      : pr=0, npr=1, cpl=2
stream_b:
    stream_control: enable=1, stream_id=2
    tx_control    : key_set_select=1, prime_key_set_0=0, prime_key_set_1=0
    keyset_0      : pr=3, npr=4, cpl=5
stream_c:
    stream_control: enable=1, stream_id=3
    tx_control    : key_set_select=1, prime_key_set_0=0, prime_key_set_1=0
    keyset_0      : pr=6, npr=7, cpl=8
stream_d:
    stream_control: enable=0, stream_id=0
key/iv slot usage: key_iv_slot_usage_map=07
Find free key/iv slots: pr=9, npr=10, cpl=11
```