### PR TITLE
Refactor ide_key_set_t in pcie_ide_test_group_context_t

### DIFF
--- a/teeio-validator/include/ide_test.h
+++ b/teeio-validator/include/ide_test.h
@@ -429,7 +429,7 @@ typedef struct {
 
   uint8_t stream_id;
   uint8_t rp_stream_index;
-  ide_key_set_t k_set[PCIE_IDE_STREAM_KS_NUM];
+  ide_key_set_t k_set;
 } pcie_ide_test_group_context_t;
 
 typedef struct {

--- a/teeio-validator/library/pcie_ide_lib/pcie_ide.c
+++ b/teeio-validator/library/pcie_ide_lib/pcie_ide.c
@@ -636,7 +636,7 @@ bool init_root_port(pcie_ide_test_group_context_t *group_context)
   dump_addr_assoc_reg_block(&port_context->addr_assoc_reg_block);
 
   // allocate key/iv slots
-  if(!pcie_ide_alloc_slot_ids(port_context, group_context->rp_stream_index, group_context->k_set)) {
+  if(!pcie_ide_alloc_slot_ids(port_context, group_context->rp_stream_index, &group_context->k_set)) {
     goto InitHostFail;
   }
 

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_full.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_full.c
@@ -39,7 +39,7 @@ bool pcie_ide_test_full_1_setup(void *test_context)
 
   return setup_ide_stream(group_context->doe_context, group_context->spdm_context, &group_context->session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id, PCI_IDE_KM_KEY_SET_K0,
-                          group_context->k_set, group_context->rp_stream_index,
+                          &group_context->k_set, group_context->rp_stream_index,
                           0, group_context->top->type, upper_port, lower_port, false);
 
 }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_full_keyrefresh.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_full_keyrefresh.c
@@ -60,7 +60,7 @@ bool pcie_ide_test_full_keyrefresh_setup(void *test_context)
   // An ide_stream is first setup so that key_refresh can be tested in run.
   return setup_ide_stream(group_context->doe_context, group_context->spdm_context, &group_context->session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id, mKeySet,
-                          group_context->k_set, group_context->rp_stream_index,
+                          &group_context->k_set, group_context->rp_stream_index,
                           0, group_context->top->type, upper_port, lower_port, false);
 }
 
@@ -122,7 +122,7 @@ bool pcie_ide_test_full_keyrefresh_run(void *test_context)
     } else {
       res = ide_key_switch_to(doe_context, spdm_context, &session_id,
                               upper_port->mapped_kcbar_addr, stream_id,
-                              group_context->k_set, group_context->rp_stream_index,
+                              &group_context->k_set, group_context->rp_stream_index,
                               0, group_context->top->type, upper_port, lower_port, mKeySet, false);
       if(!res) {
         break;

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_1.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_1.c
@@ -221,7 +221,7 @@ bool pcie_ide_test_keyprog_1_run(void *test_context)
 
   // program key in root port kcbar registers
   pcie_construct_rp_keys(key_buffer.key, sizeof(key_buffer.key), keys.bytes, sizeof(keys.bytes));
-  slot_id = group_context->k_set[ks].slot_id[direction][substream];
+  slot_id = group_context->k_set.slot_id[direction][substream];
   cfg_rootport_ide_keys(kcbar_ptr, group_context->rp_stream_index, direction, ks, substream, slot_id, &keys, &iv);
   pcie_dump_key_iv_in_rp(direction == PCIE_IDE_STREAM_RX ? "TX" : "RX", (uint8_t *)keys.bytes, sizeof(keys.bytes), (uint8_t *)iv.bytes, sizeof(iv.bytes));
 
@@ -240,7 +240,7 @@ bool pcie_ide_test_keyprog_1_run(void *test_context)
 
   // program key in root port kcbar registers
   pcie_construct_rp_keys(key_buffer.key, sizeof(key_buffer.key), keys.bytes, sizeof(keys.bytes));
-  slot_id = group_context->k_set[ks].slot_id[direction][substream];
+  slot_id = group_context->k_set.slot_id[direction][substream];
   cfg_rootport_ide_keys(kcbar_ptr, group_context->rp_stream_index, direction, ks, substream, slot_id, &keys, &iv);
   pcie_dump_key_iv_in_rp(direction == PCIE_IDE_STREAM_RX ? "TX" : "RX", (uint8_t *)keys.bytes, sizeof(keys.bytes), (uint8_t *)iv.bytes, sizeof(iv.bytes));
 
@@ -259,7 +259,7 @@ bool pcie_ide_test_keyprog_1_run(void *test_context)
 
   // program key in root port kcbar registers
   pcie_construct_rp_keys(key_buffer.key, sizeof(key_buffer.key), keys.bytes, sizeof(keys.bytes));
-  slot_id = group_context->k_set[ks].slot_id[direction][substream];
+  slot_id = group_context->k_set.slot_id[direction][substream];
   cfg_rootport_ide_keys(kcbar_ptr, group_context->rp_stream_index, direction, ks, substream, slot_id, &keys, &iv);
   pcie_dump_key_iv_in_rp(direction == PCIE_IDE_STREAM_RX ? "TX" : "RX", (uint8_t *)keys.bytes, sizeof(keys.bytes), (uint8_t *)iv.bytes, sizeof(iv.bytes));
 
@@ -284,7 +284,7 @@ bool pcie_ide_test_keyprog_1_run(void *test_context)
 
   // program key in root port kcbar registers
   pcie_construct_rp_keys(key_buffer.key, sizeof(key_buffer.key), keys.bytes, sizeof(keys.bytes));
-  slot_id = group_context->k_set[ks].slot_id[direction][substream];
+  slot_id = group_context->k_set.slot_id[direction][substream];
   cfg_rootport_ide_keys(kcbar_ptr, group_context->rp_stream_index, direction, ks, substream, slot_id, &keys, &iv);
   pcie_dump_key_iv_in_rp(direction == PCIE_IDE_STREAM_RX ? "TX" : "RX", (uint8_t *)keys.bytes, sizeof(keys.bytes), (uint8_t *)iv.bytes, sizeof(iv.bytes));
 
@@ -303,7 +303,7 @@ bool pcie_ide_test_keyprog_1_run(void *test_context)
 
   // program key in root port kcbar registers
   pcie_construct_rp_keys(key_buffer.key, sizeof(key_buffer.key), keys.bytes, sizeof(keys.bytes));
-  slot_id = group_context->k_set[ks].slot_id[direction][substream];
+  slot_id = group_context->k_set.slot_id[direction][substream];
   cfg_rootport_ide_keys(kcbar_ptr, group_context->rp_stream_index, direction, ks, substream, slot_id, &keys, &iv);
   pcie_dump_key_iv_in_rp(direction == PCIE_IDE_STREAM_RX ? "TX" : "RX", (uint8_t *)keys.bytes, sizeof(keys.bytes), (uint8_t *)iv.bytes, sizeof(iv.bytes));
 
@@ -322,7 +322,7 @@ bool pcie_ide_test_keyprog_1_run(void *test_context)
 
   // program key in root port kcbar registers
   pcie_construct_rp_keys(key_buffer.key, sizeof(key_buffer.key), keys.bytes, sizeof(keys.bytes));
-  slot_id = group_context->k_set[ks].slot_id[direction][substream];
+  slot_id = group_context->k_set.slot_id[direction][substream];
   cfg_rootport_ide_keys(kcbar_ptr, group_context->rp_stream_index, direction, ks, substream, slot_id, &keys, &iv);
   pcie_dump_key_iv_in_rp(direction == PCIE_IDE_STREAM_RX ? "TX" : "RX", (uint8_t *)keys.bytes, sizeof(keys.bytes), (uint8_t *)iv.bytes, sizeof(iv.bytes));
 

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_1.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_1.c
@@ -223,7 +223,7 @@ bool pcie_ide_test_ksetgo_1_setup(void *test_context)
 
   return test_ksetgo_setup_common(group_context->doe_context, group_context->spdm_context, &group_context->session_id,
     group_context->upper_port.mapped_kcbar_addr, group_context->stream_id, group_context->rp_stream_index,
-    group_context->upper_port.ide_id, group_context->k_set, 0, PCIE_IDE_STREAM_KS0);
+    group_context->upper_port.ide_id, &group_context->k_set, 0, PCIE_IDE_STREAM_KS0);
 }
 
 bool pcie_ide_test_ksetgo_1_run(void *test_context)

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_2.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_2.c
@@ -39,7 +39,7 @@ bool pcie_ide_test_ksetgo_2_setup(void *test_context)
 
   return test_ksetgo_setup_common(group_context->doe_context, group_context->spdm_context, &group_context->session_id,
     group_context->upper_port.mapped_kcbar_addr, group_context->stream_id, group_context->rp_stream_index,
-    group_context->upper_port.ide_id, group_context->k_set, 0, PCIE_IDE_STREAM_KS1);
+    group_context->upper_port.ide_id, &group_context->k_set, 0, PCIE_IDE_STREAM_KS1);
 }
 
 bool pcie_ide_test_ksetgo_2_run(void *test_context)

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_3.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_3.c
@@ -45,7 +45,7 @@ bool pcie_ide_test_ksetgo_3_setup(void *test_context)
   // first setup ide_stream for KS0 (skip ksetgo)
   bool res = setup_ide_stream(group_context->doe_context, group_context->spdm_context, &group_context->session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id, PCI_IDE_KM_KEY_SET_K0,
-                          group_context->k_set, group_context->rp_stream_index,
+                          &group_context->k_set, group_context->rp_stream_index,
                           0, group_context->top->type,
                           upper_port, lower_port, true);
   if(!res) {
@@ -261,7 +261,7 @@ bool pcie_ide_test_ksetgo_3_run(void *test_context)
   // then switch to KS1 (skip ksetgo)
   res = ide_key_switch_to(group_context->doe_context, group_context->spdm_context, &group_context->session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id,
-                          group_context->k_set, group_context->rp_stream_index,
+                          &group_context->k_set, group_context->rp_stream_index,
                           0, group_context->top->type, upper_port, lower_port, PCIE_IDE_STREAM_KS1, true);
   if(!res) {
     goto Done;

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_4.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_4.c
@@ -45,7 +45,7 @@ bool pcie_ide_test_ksetgo_4_setup(void *test_context)
   // first setup ide_stream for KS1 (skip ksetgo)
   bool res = setup_ide_stream(group_context->doe_context, group_context->spdm_context, &group_context->session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id, PCI_IDE_KM_KEY_SET_K1,
-                          group_context->k_set, group_context->rp_stream_index,
+                          &group_context->k_set, group_context->rp_stream_index,
                           0, group_context->top->type, upper_port, lower_port, true);
   if(!res) {
     return false;
@@ -260,7 +260,7 @@ bool pcie_ide_test_ksetgo_4_run(void *test_context)
   // then switch to KS0 (skip ksetgo)
   res = ide_key_switch_to(group_context->doe_context, group_context->spdm_context, &group_context->session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id,
-                          group_context->k_set, group_context->rp_stream_index,
+                          &group_context->k_set, group_context->rp_stream_index,
                           0, group_context->top->type, upper_port, lower_port,
                           PCIE_IDE_STREAM_KS0, true);
   if(!res) {

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_1.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_1.c
@@ -117,7 +117,7 @@ bool pcie_ide_test_ksetstop_1_setup(void *test_context)
 
   return setup_ide_stream(group_context->doe_context, group_context->spdm_context, &group_context->session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id, PCI_IDE_KM_KEY_SET_K0,
-                          group_context->k_set, group_context->rp_stream_index,
+                          &group_context->k_set, group_context->rp_stream_index,
                           0, group_context->top->type, upper_port, lower_port, false);
 
 }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_2.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_2.c
@@ -38,7 +38,7 @@ bool pcie_ide_test_ksetstop_2_setup(void *test_context)
 
   return setup_ide_stream(group_context->doe_context, group_context->spdm_context, &group_context->session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id, PCI_IDE_KM_KEY_SET_K1,
-                          group_context->k_set, group_context->rp_stream_index,
+                          &group_context->k_set, group_context->rp_stream_index,
                           0, group_context->top->type, upper_port, lower_port, false);
 
 }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_3.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_3.c
@@ -39,7 +39,7 @@ bool pcie_ide_test_ksetstop_3_setup(void *test_context)
   // first setup ide_stream for KS0
   bool res = setup_ide_stream(group_context->doe_context, group_context->spdm_context, &group_context->session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id, PCI_IDE_KM_KEY_SET_K0,
-                          group_context->k_set, group_context->rp_stream_index,
+                          &group_context->k_set, group_context->rp_stream_index,
                           0, group_context->top->type, upper_port, lower_port, false);
   if(!res) {
     return false;
@@ -48,7 +48,7 @@ bool pcie_ide_test_ksetstop_3_setup(void *test_context)
   // then switch to KS1
   res = ide_key_switch_to(group_context->doe_context, group_context->spdm_context, &group_context->session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id,
-                          group_context->k_set, group_context->rp_stream_index,
+                          &group_context->k_set, group_context->rp_stream_index,
                           0, group_context->top->type, upper_port, lower_port, PCIE_IDE_STREAM_KS1, false);
 
   return res;

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_4.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_4.c
@@ -39,7 +39,7 @@ bool pcie_ide_test_ksetstop_4_setup(void *test_context)
   // first setup ide_stream for KS1
   bool res = setup_ide_stream(group_context->doe_context, group_context->spdm_context, &group_context->session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id, PCI_IDE_KM_KEY_SET_K1,
-                          group_context->k_set, group_context->rp_stream_index,
+                          &group_context->k_set, group_context->rp_stream_index,
                           0, group_context->top->type, upper_port, lower_port, false);
   if(!res) {
     return false;
@@ -48,7 +48,7 @@ bool pcie_ide_test_ksetstop_4_setup(void *test_context)
   // then switch to KS0
   res = ide_key_switch_to(group_context->doe_context, group_context->spdm_context, &group_context->session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id,
-                          group_context->k_set, group_context->rp_stream_index,
+                          &group_context->k_set, group_context->rp_stream_index,
                           0, group_context->top->type,
                           upper_port, lower_port,
                           PCI_IDE_KM_KEY_SET_K0, false);


### PR DESCRIPTION
Fix #158 

After key/iv slot is allocated in run-time, there is only 1 ide_key_set_t needed in pcie_ide_test_group_context_t structure.