### PR TITLE
Refactor pcie_context and cxl_context_t

### DIFF
--- a/teeio-validator/include/ide_test.h
+++ b/teeio-validator/include/ide_test.h
@@ -409,23 +409,14 @@ typedef struct {
 } teeio_common_test_group_context_t;
 
 typedef struct {
-  // start of common part of test_group_context
-  uint32_t signature;
-  ide_common_test_suite_context_t *suite_context;
-  IDE_TEST_TOPOLOGY *top;
-  int config_id;
-
-  ide_common_test_port_context_t root_port;
-  ide_common_test_port_context_t upper_port;
-  ide_common_test_port_context_t lower_port;
-
-  ide_common_test_switch_internal_conn_context_t* sw_conn1;
-  ide_common_test_switch_internal_conn_context_t* sw_conn2;
-  // end of common part of test_group_context
-
   void *spdm_context;
   uint32_t session_id;
   void *doe_context;
+} spdm_doe_context_t;
+
+typedef struct {
+  teeio_common_test_group_context_t common;
+  spdm_doe_context_t spdm_doe;
 
   uint8_t stream_id;
   uint8_t rp_stream_index;
@@ -433,27 +424,11 @@ typedef struct {
 } pcie_ide_test_group_context_t;
 
 typedef struct {
-  // start of common part of test_group_context
-  uint32_t signature;
-  ide_common_test_suite_context_t *suite_context;
-  IDE_TEST_TOPOLOGY *top;
-  int config_id;
+  teeio_common_test_group_context_t common;
 
-  ide_common_test_port_context_t root_port;
-  ide_common_test_port_context_t upper_port;
-  ide_common_test_port_context_t lower_port;
-
-  ide_common_test_switch_internal_conn_context_t* sw_conn1;
-  ide_common_test_switch_internal_conn_context_t* sw_conn2;
-  // end of common part of test_group_context
-
-  void *spdm_context;
-  uint32_t session_id;
-  void *doe_context;
+  spdm_doe_context_t spdm_doe;
 
   uint8_t stream_id;
-  uint8_t rp_stream_index;
-  ide_key_set_t k_set[PCIE_IDE_STREAM_KS_NUM];
 } cxl_ide_test_group_context_t;
 
 typedef struct {

--- a/teeio-validator/library/cxl_ide_lib/cxl_ide.c
+++ b/teeio-validator/library/cxl_ide_lib/cxl_ide.c
@@ -101,13 +101,13 @@ void cxl_clear_rootport_key_ivs(ide_common_test_port_context_t* port_context)
 bool cxl_init_root_port(cxl_ide_test_group_context_t *group_context)
 {
   TEEIO_ASSERT(group_context != NULL);
-  TEEIO_ASSERT(group_context->top != NULL);
+  TEEIO_ASSERT(group_context->common.top != NULL);
 
-  ide_common_test_port_context_t *port_context = &group_context->upper_port;
+  ide_common_test_port_context_t *port_context = &group_context->common.upper_port;
   TEEIO_ASSERT(port_context != NULL);
   TEEIO_ASSERT(port_context->port != NULL);
   TEEIO_ASSERT(port_context->port->port_type == IDE_PORT_TYPE_ROOTPORT);
-  TEEIO_ASSERT(group_context->upper_port.port->id == group_context->root_port.port->id);
+  TEEIO_ASSERT(group_context->common.upper_port.port->id == group_context->common.root_port.port->id);
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "cxl_init_root_port start.\n"));
 
@@ -487,7 +487,7 @@ bool cxl_init_memcache_reg_block(int cfg_space_fd, CXL_PRIV_DATA_MEMCACHE_REG_DA
 bool cxl_close_root_port(cxl_ide_test_group_context_t *group_context)
 {
   // clean Control Registers @ecap and KCBar corresponding registers
-  ide_common_test_port_context_t* port_context = &group_context->upper_port;
+  ide_common_test_port_context_t* port_context = &group_context->common.upper_port;
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "close cxl rootport %s(%s)\n", port_context->port->port_name, port_context->port->bdf));
 
   cxl_reset_ecap_registers(port_context);
@@ -497,17 +497,17 @@ bool cxl_close_root_port(cxl_ide_test_group_context_t *group_context)
 
   cxl_unmap_memcache_reg_block(cxl_data->memcache.mapped_fd, cxl_data->memcache.mapped_memcache_reg_block);
 
-  if(group_context->upper_port.kcbar_fd > 0) {
-    unmap_kcbar_addr(group_context->upper_port.kcbar_fd, group_context->upper_port.mapped_kcbar_addr);
+  if(group_context->common.upper_port.kcbar_fd > 0) {
+    unmap_kcbar_addr(group_context->common.upper_port.kcbar_fd, group_context->common.upper_port.mapped_kcbar_addr);
   }
-  group_context->upper_port.kcbar_fd = 0;
-  group_context->upper_port.mapped_kcbar_addr = 0;
+  group_context->common.upper_port.kcbar_fd = 0;
+  group_context->common.upper_port.mapped_kcbar_addr = 0;
 
-  if(group_context->upper_port.cfg_space_fd > 0) {
-    close(group_context->upper_port.cfg_space_fd);
-    unset_device_info(group_context->upper_port.cfg_space_fd);
+  if(group_context->common.upper_port.cfg_space_fd > 0) {
+    close(group_context->common.upper_port.cfg_space_fd);
+    unset_device_info(group_context->common.upper_port.cfg_space_fd);
   }
-  group_context->upper_port.cfg_space_fd = 0;
+  group_context->common.upper_port.cfg_space_fd = 0;
   
   memset(&port_context->cxl_data, 0, sizeof(CXL_PRIV_DATA));
 
@@ -520,13 +520,13 @@ bool cxl_close_root_port(cxl_ide_test_group_context_t *group_context)
 bool cxl_init_dev_port(cxl_ide_test_group_context_t *group_context)
 {
   TEEIO_ASSERT(group_context != NULL);
-  TEEIO_ASSERT(group_context->top != NULL);
+  TEEIO_ASSERT(group_context->common.top != NULL);
 
-  TEEIO_ASSERT(group_context->suite_context->test_category == TEEIO_TEST_CATEGORY_CXL_IDE);
+  TEEIO_ASSERT(group_context->common.suite_context->test_category == TEEIO_TEST_CATEGORY_CXL_IDE);
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "cxl_init_dev_port start.\n"));
 
-  ide_common_test_port_context_t *port_context = &group_context->lower_port;
+  ide_common_test_port_context_t *port_context = &group_context->common.lower_port;
   TEEIO_ASSERT(port_context != NULL);
 
   if(!cxl_open_dev_port(port_context)) {

--- a/teeio-validator/library/cxl_ide_test_lib/cxl_ide_common.c
+++ b/teeio-validator/library/cxl_ide_test_lib/cxl_ide_common.c
@@ -176,7 +176,7 @@ static void* alloc_cxl_ide_test_group_context(void)
   cxl_ide_test_group_context_t* context = (cxl_ide_test_group_context_t*)malloc(sizeof(cxl_ide_test_group_context_t));
   TEEIO_ASSERT(context);
   memset(context, 0, sizeof(cxl_ide_test_group_context_t));
-  context->signature = GROUP_CONTEXT_SIGNATURE;
+  context->common.signature = GROUP_CONTEXT_SIGNATURE;
 
   return context;
 }

--- a/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_full.c
+++ b/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_full.c
@@ -46,16 +46,16 @@ bool cxl_ide_test_full_ide_stream_setup(void *test_context)
 
   cxl_ide_test_group_context_t *group_context = case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
-  ide_common_test_port_context_t *upper_port = &group_context->upper_port;
-  ide_common_test_port_context_t *lower_port = &group_context->lower_port;
+  ide_common_test_port_context_t *upper_port = &group_context->common.upper_port;
+  ide_common_test_port_context_t *lower_port = &group_context->common.lower_port;
 
-  IDE_TEST_CONFIGURATION *configuration = get_configuration_by_id(group_context->suite_context->test_config, group_context->config_id);
+  IDE_TEST_CONFIGURATION *configuration = get_configuration_by_id(group_context->common.suite_context->test_config, group_context->common.config_id);
   TEEIO_ASSERT(configuration);
 
-  return cxl_setup_ide_stream(group_context->doe_context, group_context->spdm_context,
-                              &group_context->session_id, upper_port->mapped_kcbar_addr,
+  return cxl_setup_ide_stream(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context,
+                              &group_context->spdm_doe.session_id, upper_port->mapped_kcbar_addr,
                               group_context->stream_id, 0,
                               upper_port, lower_port, false, configuration->bit_map);
 }
@@ -68,11 +68,11 @@ bool cxl_ide_test_full_ide_stream_run(void *test_context)
 
   cxl_ide_test_group_context_t *group_context = (cxl_ide_test_group_context_t *)case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
-  INTEL_KEYP_CXL_ROOT_COMPLEX_KCBAR *kcbar_ptr = (INTEL_KEYP_CXL_ROOT_COMPLEX_KCBAR *)group_context->upper_port.mapped_kcbar_addr;
-  ide_common_test_port_context_t* upper_port = &group_context->upper_port;
-  ide_common_test_port_context_t* lower_port = &group_context->lower_port;
+  INTEL_KEYP_CXL_ROOT_COMPLEX_KCBAR *kcbar_ptr = (INTEL_KEYP_CXL_ROOT_COMPLEX_KCBAR *)group_context->common.upper_port.mapped_kcbar_addr;
+  ide_common_test_port_context_t* upper_port = &group_context->common.upper_port;
+  ide_common_test_port_context_t* lower_port = &group_context->common.lower_port;
 
   // Now ide stream shall be in secure state
   // Dump registers to check
@@ -106,18 +106,18 @@ bool cxl_ide_test_full_ide_stream_teardown(void *test_context)
 
   cxl_ide_test_group_context_t *group_context = case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
-  ide_common_test_port_context_t *upper_port = &group_context->upper_port;
-  ide_common_test_port_context_t *lower_port = &group_context->lower_port;
+  ide_common_test_port_context_t *upper_port = &group_context->common.upper_port;
+  ide_common_test_port_context_t *lower_port = &group_context->common.lower_port;
 
   CXL_QUERY_RESP_CAPS dev_caps = {.raw = lower_port->cxl_data.query_resp.caps};
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "dev_caps.k_set_stop_capable = %d\n", dev_caps.k_set_stop_capable));
 
   // send KSetStop if supported.
   if(dev_caps.k_set_stop_capable == 1) {
-    ret = cxl_stop_ide_stream(group_context->doe_context, group_context->spdm_context,
-                              &group_context->session_id, upper_port->mapped_kcbar_addr,
+    ret = cxl_stop_ide_stream(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context,
+                              &group_context->spdm_doe.session_id, upper_port->mapped_kcbar_addr,
                               group_context->stream_id, 0,
                               upper_port, lower_port);
     if(!ret) {

--- a/teeio-validator/library/cxl_ide_test_lib/test_config/test_config_containment.c
+++ b/teeio-validator/library/cxl_ide_test_lib/test_config/test_config_containment.c
@@ -23,9 +23,9 @@ bool cxl_ide_test_config_containment_enable(void *test_context)
   TEEIO_ASSERT(config_context->signature == CONFIG_CONTEXT_SIGNATURE);
 
   cxl_ide_test_group_context_t *group_context = config_context->group_context;
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
-  INTEL_KEYP_CXL_ROOT_COMPLEX_KCBAR* kcbar_ptr = (INTEL_KEYP_CXL_ROOT_COMPLEX_KCBAR *)group_context->upper_port.mapped_kcbar_addr;
+  INTEL_KEYP_CXL_ROOT_COMPLEX_KCBAR* kcbar_ptr = (INTEL_KEYP_CXL_ROOT_COMPLEX_KCBAR *)group_context->common.upper_port.mapped_kcbar_addr;
   cxl_cfg_rp_mode(kcbar_ptr, INTEL_CXL_IDE_MODE_CONTAINMENT);
 
   return true;
@@ -42,10 +42,10 @@ bool cxl_ide_test_config_containment_support(void *test_context)
   TEEIO_ASSERT(config_context->signature == CONFIG_CONTEXT_SIGNATURE);
 
   cxl_ide_test_group_context_t *group_context = config_context->group_context;
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
-  CXL_PRIV_DATA* rp_cxl_data = &group_context->upper_port.cxl_data;
-  CXL_PRIV_DATA* ep_cxl_data = &group_context->lower_port.cxl_data;
+  CXL_PRIV_DATA* rp_cxl_data = &group_context->common.upper_port.cxl_data;
+  CXL_PRIV_DATA* ep_cxl_data = &group_context->common.lower_port.cxl_data;
 
   bool supported = rp_cxl_data->memcache.ide_cap.cxl_ide_capable == 1
                   && (rp_cxl_data->memcache.ide_cap.raw & (uint32_t)CXL_IDE_MODE_CONTAINMENT_MASK) != 0

--- a/teeio-validator/library/cxl_ide_test_lib/test_config/test_config_default.c
+++ b/teeio-validator/library/cxl_ide_test_lib/test_config/test_config_default.c
@@ -33,10 +33,10 @@ bool cxl_ide_test_config_default_support(void *test_context)
   TEEIO_ASSERT(config_context->signature == CONFIG_CONTEXT_SIGNATURE);
 
   cxl_ide_test_group_context_t *group_context = config_context->group_context;
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
-  CXL_PRIV_DATA* rp_cxl_data = &group_context->upper_port.cxl_data;
-  CXL_PRIV_DATA* ep_cxl_data = &group_context->lower_port.cxl_data;
+  CXL_PRIV_DATA* rp_cxl_data = &group_context->common.upper_port.cxl_data;
+  CXL_PRIV_DATA* ep_cxl_data = &group_context->common.lower_port.cxl_data;
 
   bool supported = rp_cxl_data->memcache.ide_cap.cxl_ide_capable == 1 && ep_cxl_data->memcache.ide_cap.cxl_ide_capable == 1
                   && ep_cxl_data->ecap.cap.mem_capable == 1;

--- a/teeio-validator/library/cxl_ide_test_lib/test_config/test_config_get_key.c
+++ b/teeio-validator/library/cxl_ide_test_lib/test_config/test_config_get_key.c
@@ -34,9 +34,9 @@ bool cxl_ide_test_config_get_key_support(void *test_context)
   TEEIO_ASSERT(config_context->signature == CONFIG_CONTEXT_SIGNATURE);
 
   cxl_ide_test_group_context_t *group_context = config_context->group_context;
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
-  CXL_PRIV_DATA* ep_cxl_data = &group_context->lower_port.cxl_data;
+  CXL_PRIV_DATA* ep_cxl_data = &group_context->common.lower_port.cxl_data;
 
   CXL_QUERY_RESP_CAPS dev_caps = {.raw = ep_cxl_data->query_resp.caps};
 

--- a/teeio-validator/library/cxl_ide_test_lib/test_config/test_config_skid.c
+++ b/teeio-validator/library/cxl_ide_test_lib/test_config/test_config_skid.c
@@ -23,9 +23,9 @@ bool cxl_ide_test_config_skid_enable(void *test_context)
   TEEIO_ASSERT(config_context->signature == CONFIG_CONTEXT_SIGNATURE);
 
   cxl_ide_test_group_context_t *group_context = config_context->group_context;
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
-  INTEL_KEYP_CXL_ROOT_COMPLEX_KCBAR* kcbar_ptr = (INTEL_KEYP_CXL_ROOT_COMPLEX_KCBAR *)group_context->upper_port.mapped_kcbar_addr;
+  INTEL_KEYP_CXL_ROOT_COMPLEX_KCBAR* kcbar_ptr = (INTEL_KEYP_CXL_ROOT_COMPLEX_KCBAR *)group_context->common.upper_port.mapped_kcbar_addr;
   cxl_cfg_rp_mode(kcbar_ptr, INTEL_CXL_IDE_MODE_SKID);
 
   return true;
@@ -42,10 +42,10 @@ bool cxl_ide_test_config_skid_support(void *test_context)
   TEEIO_ASSERT(config_context->signature == CONFIG_CONTEXT_SIGNATURE);
 
   cxl_ide_test_group_context_t *group_context = config_context->group_context;
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
-  CXL_PRIV_DATA* rp_cxl_data = &group_context->upper_port.cxl_data;
-  CXL_PRIV_DATA* ep_cxl_data = &group_context->lower_port.cxl_data;
+  CXL_PRIV_DATA* rp_cxl_data = &group_context->common.upper_port.cxl_data;
+  CXL_PRIV_DATA* ep_cxl_data = &group_context->common.lower_port.cxl_data;
 
   bool supported = rp_cxl_data->memcache.ide_cap.cxl_ide_capable == 1
                   && (rp_cxl_data->memcache.ide_cap.raw & (uint32_t)CXL_IDE_MODE_SKID_MASK) != 0

--- a/teeio-validator/library/pcie_ide_test_lib/pcie_ide_common.c
+++ b/teeio-validator/library/pcie_ide_test_lib/pcie_ide_common.c
@@ -222,7 +222,7 @@ static void* alloc_pcie_ide_test_group_context(void)
   pcie_ide_test_group_context_t* context = (pcie_ide_test_group_context_t*)malloc(sizeof(pcie_ide_test_group_context_t));
   TEEIO_ASSERT(context);
   memset(context, 0, sizeof(pcie_ide_test_group_context_t));
-  context->signature = GROUP_CONTEXT_SIGNATURE;
+  context->common.signature = GROUP_CONTEXT_SIGNATURE;
 
   return context;
 }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_full.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_full.c
@@ -32,15 +32,15 @@ bool pcie_ide_test_full_1_setup(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
-  ide_common_test_port_context_t* upper_port = &group_context->upper_port;
-  ide_common_test_port_context_t* lower_port = &group_context->lower_port;
+  ide_common_test_port_context_t* upper_port = &group_context->common.upper_port;
+  ide_common_test_port_context_t* lower_port = &group_context->common.lower_port;
 
-  return setup_ide_stream(group_context->doe_context, group_context->spdm_context, &group_context->session_id,
+  return setup_ide_stream(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id, PCI_IDE_KM_KEY_SET_K0,
                           &group_context->k_set, group_context->rp_stream_index,
-                          0, group_context->top->type, upper_port, lower_port, false);
+                          0, group_context->common.top->type, upper_port, lower_port, false);
 
 }
 
@@ -52,14 +52,14 @@ bool pcie_ide_test_full_1_run(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = (pcie_ide_test_group_context_t *)case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
   TEST_IDE_TYPE ide_type = TEST_IDE_TYPE_SEL_IDE;
-  if (group_context->top->type == IDE_TEST_TOPOLOGY_TYPE_LINK_IDE)
+  if (group_context->common.top->type == IDE_TEST_TOPOLOGY_TYPE_LINK_IDE)
   {
     ide_type = IDE_TEST_TOPOLOGY_TYPE_LINK_IDE;
   }
-  else if(group_context->top->type == IDE_TEST_TOPOLOGY_TYPE_SEL_LINK_IDE)
+  else if(group_context->common.top->type == IDE_TEST_TOPOLOGY_TYPE_SEL_LINK_IDE)
   {
     NOT_IMPLEMENTED("selective_and_link_ide topoplogy");
   }
@@ -67,18 +67,18 @@ bool pcie_ide_test_full_1_run(void *test_context)
   // dump registers
   TEEIO_PRINT(("\n"));
   TEEIO_PRINT(("Print host registers.\n"));
-  dump_rootport_registers(group_context->upper_port.mapped_kcbar_addr,
+  dump_rootport_registers(group_context->common.upper_port.mapped_kcbar_addr,
                     group_context->rp_stream_index,
-                    group_context->upper_port.cfg_space_fd,
-                    group_context->upper_port.ide_id,
-                    group_context->upper_port.ecap_offset,
+                    group_context->common.upper_port.cfg_space_fd,
+                    group_context->common.upper_port.ide_id,
+                    group_context->common.upper_port.ecap_offset,
                     ide_type);
 
   TEEIO_PRINT(("\n"));
   TEEIO_PRINT(("Print device registers.\n"));
-  dump_dev_registers(group_context->lower_port.cfg_space_fd,
-                    group_context->lower_port.ide_id,
-                    group_context->lower_port.ecap_offset,
+  dump_dev_registers(group_context->common.lower_port.cfg_space_fd,
+                    group_context->common.lower_port.ide_id,
+                    group_context->common.lower_port.ecap_offset,
                     ide_type);
 
   TEEIO_PRINT(("ide_stream is setup. Press any key to continue.\n"));
@@ -163,12 +163,12 @@ bool test_full_teardown_common(void *test_context, uint8_t ks)
 
   pcie_ide_test_group_context_t *group_context = case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
-  ide_common_test_port_context_t* upper_port = &group_context->upper_port;
-  ide_common_test_port_context_t* lower_port = &group_context->lower_port;
+  ide_common_test_port_context_t* upper_port = &group_context->common.upper_port;
+  ide_common_test_port_context_t* lower_port = &group_context->common.lower_port;
 
-  IDE_TEST_TOPOLOGY_TYPE top_type = group_context->top->type;
+  IDE_TEST_TOPOLOGY_TYPE top_type = group_context->common.top->type;
 
   // disable dev ide
   TEST_IDE_TYPE ide_type = TEST_IDE_TYPE_SEL_IDE;
@@ -190,9 +190,9 @@ bool test_full_teardown_common(void *test_context, uint8_t ks)
                          upper_port->mapped_kcbar_addr,
                          group_context->rp_stream_index, false);
 
-  void* doe_context = group_context->doe_context;
-  void* spdm_context = group_context->spdm_context;
-  uint32_t session_id = group_context->session_id;
+  void* doe_context = group_context->spdm_doe.doe_context;
+  void* spdm_context = group_context->spdm_doe.spdm_context;
+  uint32_t session_id = group_context->spdm_doe.session_id;
   uint8_t stream_id = group_context->stream_id;
   uint8_t port_index = 0;
   bool res = false;

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_full_keyrefresh.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_full_keyrefresh.c
@@ -34,18 +34,18 @@ bool pcie_ide_test_full_keyrefresh_setup(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
-  ide_common_test_port_context_t* upper_port = &group_context->upper_port;
-  ide_common_test_port_context_t* lower_port = &group_context->lower_port;
+  ide_common_test_port_context_t* upper_port = &group_context->common.upper_port;
+  ide_common_test_port_context_t* lower_port = &group_context->common.lower_port;
 
   mKeySet = PCI_IDE_KM_KEY_SET_K0;
 
   // An ide_stream is first setup so that key_refresh can be tested in run.
-  return setup_ide_stream(group_context->doe_context, group_context->spdm_context, &group_context->session_id,
+  return setup_ide_stream(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id, mKeySet,
                           &group_context->k_set, group_context->rp_stream_index,
-                          0, group_context->top->type, upper_port, lower_port, false);
+                          0, group_context->common.top->type, upper_port, lower_port, false);
 }
 
 bool pcie_ide_test_full_keyrefresh_run(void *test_context)
@@ -56,22 +56,22 @@ bool pcie_ide_test_full_keyrefresh_run(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = (pcie_ide_test_group_context_t *)case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
   uint8_t stream_id = group_context->stream_id;
-  void *doe_context = group_context->doe_context;
-  void *spdm_context = group_context->spdm_context;
-  uint32_t session_id = group_context->session_id;
+  void *doe_context = group_context->spdm_doe.doe_context;
+  void *spdm_context = group_context->spdm_doe.spdm_context;
+  uint32_t session_id = group_context->spdm_doe.session_id;
 
-  ide_common_test_port_context_t* upper_port = &group_context->upper_port;
-  ide_common_test_port_context_t* lower_port = &group_context->lower_port;
+  ide_common_test_port_context_t* upper_port = &group_context->common.upper_port;
+  ide_common_test_port_context_t* lower_port = &group_context->common.lower_port;
 
   TEST_IDE_TYPE ide_type = TEST_IDE_TYPE_SEL_IDE;
-  if (group_context->top->type == IDE_TEST_TOPOLOGY_TYPE_LINK_IDE)
+  if (group_context->common.top->type == IDE_TEST_TOPOLOGY_TYPE_LINK_IDE)
   {
     ide_type = IDE_TEST_TOPOLOGY_TYPE_LINK_IDE;
   }
-  else if(group_context->top->type == IDE_TEST_TOPOLOGY_TYPE_SEL_LINK_IDE)
+  else if(group_context->common.top->type == IDE_TEST_TOPOLOGY_TYPE_SEL_LINK_IDE)
   {
     NOT_IMPLEMENTED("selective_and_link_ide topoplogy");
   }
@@ -83,18 +83,18 @@ bool pcie_ide_test_full_keyrefresh_run(void *test_context)
     TEEIO_PRINT(("\n"));
     TEEIO_PRINT(("Current KeySet=%d. Check the registers below.\n", mKeySet));
     TEEIO_PRINT(("Print host registers.\n"));
-    dump_rootport_registers(group_context->upper_port.mapped_kcbar_addr,
+    dump_rootport_registers(group_context->common.upper_port.mapped_kcbar_addr,
                       group_context->rp_stream_index,
-                      group_context->upper_port.cfg_space_fd,
-                      group_context->upper_port.ide_id,
-                      group_context->upper_port.ecap_offset,
+                      group_context->common.upper_port.cfg_space_fd,
+                      group_context->common.upper_port.ide_id,
+                      group_context->common.upper_port.ecap_offset,
                       ide_type);
 
     TEEIO_PRINT(("\n"));
     TEEIO_PRINT(("Print device registers.\n"));
-    dump_dev_registers(group_context->lower_port.cfg_space_fd,
-                      group_context->lower_port.ide_id,
-                      group_context->lower_port.ecap_offset,
+    dump_dev_registers(group_context->common.lower_port.cfg_space_fd,
+                      group_context->common.lower_port.ide_id,
+                      group_context->common.lower_port.ecap_offset,
                       ide_type);
 
     mKeySet = mKeySet == PCI_IDE_KM_KEY_SET_K0 ? PCI_IDE_KM_KEY_SET_K1 : PCI_IDE_KM_KEY_SET_K0;
@@ -107,7 +107,7 @@ bool pcie_ide_test_full_keyrefresh_run(void *test_context)
       res = ide_key_switch_to(doe_context, spdm_context, &session_id,
                               upper_port->mapped_kcbar_addr, stream_id,
                               &group_context->k_set, group_context->rp_stream_index,
-                              0, group_context->top->type, upper_port, lower_port, mKeySet, false);
+                              0, group_context->common.top->type, upper_port, lower_port, mKeySet, false);
       if(!res) {
         break;
       }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_1.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_1.c
@@ -50,15 +50,15 @@ bool test_keyprog_setup_common(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
-  TEEIO_ASSERT(group_context->spdm_context);
-  TEEIO_ASSERT(group_context->session_id);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->spdm_doe.spdm_context);
+  TEEIO_ASSERT(group_context->spdm_doe.session_id);
 
   // query
   ide_reg_block_count = PCI_IDE_KM_IDE_REG_BLOCK_SUPPORTED_COUNT;
-  status = pci_ide_km_query(group_context->doe_context,
-                            group_context->spdm_context,
-                            &group_context->session_id,
+  status = pci_ide_km_query(group_context->spdm_doe.doe_context,
+                            group_context->spdm_doe.spdm_context,
+                            &group_context->spdm_doe.session_id,
                             0,
                             &dev_func_num,
                             &bus_num,
@@ -178,18 +178,18 @@ bool pcie_ide_test_keyprog_1_run(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = (pcie_ide_test_group_context_t *)case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
   uint8_t stream_id = group_context->stream_id;
-  void *doe_context = group_context->doe_context;
-  void *spdm_context = group_context->spdm_context;
-  uint32_t session_id = group_context->session_id;
+  void *doe_context = group_context->spdm_doe.doe_context;
+  void *spdm_context = group_context->spdm_doe.spdm_context;
+  uint32_t session_id = group_context->spdm_doe.session_id;
 
   INTEL_KEYP_KEY_SLOT keys = {0};
   INTEL_KEYP_IV_SLOT iv = {0};
   pci_ide_km_aes_256_gcm_key_buffer_t key_buffer;
   uint8_t kp_ack_status;
-  INTEL_KEYP_ROOT_COMPLEX_KCBAR *kcbar_ptr = (INTEL_KEYP_ROOT_COMPLEX_KCBAR *)group_context->upper_port.mapped_kcbar_addr;
+  INTEL_KEYP_ROOT_COMPLEX_KCBAR *kcbar_ptr = (INTEL_KEYP_ROOT_COMPLEX_KCBAR *)group_context->common.upper_port.mapped_kcbar_addr;
   uint8_t slot_id;
   uint8_t ks;
   uint8_t direction;

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_2.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_2.c
@@ -128,12 +128,12 @@ bool pcie_ide_test_keyprog_2_run(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = (pcie_ide_test_group_context_t *)case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
   uint8_t stream_id = group_context->stream_id;
-  void *doe_context = group_context->doe_context;
-  void *spdm_context = group_context->spdm_context;
-  uint32_t session_id = group_context->session_id;
+  void *doe_context = group_context->spdm_doe.doe_context;
+  void *spdm_context = group_context->spdm_doe.spdm_context;
+  uint32_t session_id = group_context->spdm_doe.session_id;
 
   pci_ide_km_aes_256_gcm_key_buffer_t key_buffer;
   uint8_t kp_ack_status;

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_3.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_3.c
@@ -125,9 +125,9 @@ bool pcie_ide_test_keyprog_3_setup(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
-  TEEIO_ASSERT(group_context->spdm_context);
-  TEEIO_ASSERT(group_context->session_id);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->spdm_doe.spdm_context);
+  TEEIO_ASSERT(group_context->spdm_doe.session_id);
 
   bool res = test_keyprog_setup_common(test_context);
   if(res) {
@@ -150,12 +150,12 @@ bool pcie_ide_test_keyprog_3_run(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = (pcie_ide_test_group_context_t *)case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
   uint8_t stream_id = group_context->stream_id;
-  void *doe_context = group_context->doe_context;
-  void *spdm_context = group_context->spdm_context;
-  uint32_t session_id = group_context->session_id;
+  void *doe_context = group_context->spdm_doe.doe_context;
+  void *spdm_context = group_context->spdm_doe.spdm_context;
+  uint32_t session_id = group_context->spdm_doe.session_id;
 
   pci_ide_km_aes_256_gcm_key_buffer_t key_buffer;
   uint8_t kp_ack_status;

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_4.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_4.c
@@ -130,12 +130,12 @@ bool pcie_ide_test_keyprog_4_run(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = (pcie_ide_test_group_context_t *)case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
   uint8_t stream_id = group_context->stream_id;
-  void *doe_context = group_context->doe_context;
-  void *spdm_context = group_context->spdm_context;
-  uint32_t session_id = group_context->session_id;
+  void *doe_context = group_context->spdm_doe.doe_context;
+  void *spdm_context = group_context->spdm_doe.spdm_context;
+  uint32_t session_id = group_context->spdm_doe.session_id;
 
   pci_ide_km_aes_256_gcm_key_buffer_t key_buffer;
   uint8_t kp_ack_status;

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_5.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_5.c
@@ -130,12 +130,12 @@ bool pcie_ide_test_keyprog_5_run(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = (pcie_ide_test_group_context_t *)case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
   uint8_t stream_id = group_context->stream_id;
-  void *doe_context = group_context->doe_context;
-  void *spdm_context = group_context->spdm_context;
-  uint32_t session_id = group_context->session_id;
+  void *doe_context = group_context->spdm_doe.doe_context;
+  void *spdm_context = group_context->spdm_doe.spdm_context;
+  uint32_t session_id = group_context->spdm_doe.session_id;
 
   pci_ide_km_aes_256_gcm_key_buffer_t key_buffer;
   uint8_t kp_ack_status;

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_6.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_6.c
@@ -130,12 +130,12 @@ bool pcie_ide_test_keyprog_6_run(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = (pcie_ide_test_group_context_t *)case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
   uint8_t stream_id = group_context->stream_id;
-  void *doe_context = group_context->doe_context;
-  void *spdm_context = group_context->spdm_context;
-  uint32_t session_id = group_context->session_id;
+  void *doe_context = group_context->spdm_doe.doe_context;
+  void *spdm_context = group_context->spdm_doe.spdm_context;
+  uint32_t session_id = group_context->spdm_doe.session_id;
 
   pci_ide_km_aes_256_gcm_key_buffer_t key_buffer;
   uint8_t kp_ack_status;

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_1.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_1.c
@@ -217,13 +217,13 @@ bool pcie_ide_test_ksetgo_1_setup(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
-  TEEIO_ASSERT(group_context->spdm_context);
-  TEEIO_ASSERT(group_context->session_id);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->spdm_doe.spdm_context);
+  TEEIO_ASSERT(group_context->spdm_doe.session_id);
 
-  return test_ksetgo_setup_common(group_context->doe_context, group_context->spdm_context, &group_context->session_id,
-    group_context->upper_port.mapped_kcbar_addr, group_context->stream_id, group_context->rp_stream_index,
-    group_context->upper_port.ide_id, &group_context->k_set, 0, PCIE_IDE_STREAM_KS0);
+  return test_ksetgo_setup_common(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
+    group_context->common.upper_port.mapped_kcbar_addr, group_context->stream_id, group_context->rp_stream_index,
+    group_context->common.upper_port.ide_id, &group_context->k_set, 0, PCIE_IDE_STREAM_KS0);
 }
 
 bool pcie_ide_test_ksetgo_1_run(void *test_context)
@@ -237,12 +237,12 @@ bool pcie_ide_test_ksetgo_1_run(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = (pcie_ide_test_group_context_t *)case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
   uint8_t stream_id = group_context->stream_id;
-  void *doe_context = group_context->doe_context;
-  void *spdm_context = group_context->spdm_context;
-  uint32_t session_id = group_context->session_id;
+  void *doe_context = group_context->spdm_doe.doe_context;
+  void *spdm_context = group_context->spdm_doe.spdm_context;
+  uint32_t session_id = group_context->spdm_doe.session_id;
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetGo K0|RX|PR\n"));
   status = test_ide_km_key_set_go(doe_context, spdm_context, &session_id, stream_id,
@@ -269,7 +269,7 @@ bool pcie_ide_test_ksetgo_1_run(void *test_context)
   }
 
   // set key_set_select in host ide
-  INTEL_KEYP_ROOT_COMPLEX_KCBAR *kcbar = (INTEL_KEYP_ROOT_COMPLEX_KCBAR *)group_context->upper_port.mapped_kcbar_addr;
+  INTEL_KEYP_ROOT_COMPLEX_KCBAR *kcbar = (INTEL_KEYP_ROOT_COMPLEX_KCBAR *)group_context->common.upper_port.mapped_kcbar_addr;
   set_rp_ide_key_set_select(kcbar, group_context->rp_stream_index, PCIE_IDE_STREAM_KS0);
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetGo K0|TX|PR\n"));
@@ -298,21 +298,21 @@ bool pcie_ide_test_ksetgo_1_run(void *test_context)
 
   // enable dev ide
   TEST_IDE_TYPE ide_type = TEST_IDE_TYPE_SEL_IDE;
-  if (group_context->top->type == IDE_TEST_TOPOLOGY_TYPE_LINK_IDE)
+  if (group_context->common.top->type == IDE_TEST_TOPOLOGY_TYPE_LINK_IDE)
   {
     ide_type = IDE_TEST_TOPOLOGY_TYPE_LINK_IDE;
   }
-  else if(group_context->top->type == IDE_TEST_TOPOLOGY_TYPE_SEL_LINK_IDE)
+  else if(group_context->common.top->type == IDE_TEST_TOPOLOGY_TYPE_SEL_LINK_IDE)
   {
     NOT_IMPLEMENTED("selective_and_link_ide topoplogy");
   }
-  enable_ide_stream_in_ecap(group_context->lower_port.cfg_space_fd, group_context->lower_port.ecap_offset, ide_type, group_context->lower_port.ide_id, true);
+  enable_ide_stream_in_ecap(group_context->common.lower_port.cfg_space_fd, group_context->common.lower_port.ecap_offset, ide_type, group_context->common.lower_port.ide_id, true);
 
   // enable host ide stream
-  enable_rootport_ide_stream(group_context->upper_port.cfg_space_fd,
-                         group_context->upper_port.ecap_offset,
-                         ide_type, group_context->upper_port.ide_id,
-                         group_context->upper_port.mapped_kcbar_addr,
+  enable_rootport_ide_stream(group_context->common.upper_port.cfg_space_fd,
+                         group_context->common.upper_port.ecap_offset,
+                         ide_type, group_context->common.upper_port.ide_id,
+                         group_context->common.upper_port.mapped_kcbar_addr,
                          group_context->rp_stream_index, true);
 
   res = true;

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_2.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_2.c
@@ -33,13 +33,13 @@ bool pcie_ide_test_ksetgo_2_setup(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
-  TEEIO_ASSERT(group_context->spdm_context);
-  TEEIO_ASSERT(group_context->session_id);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->spdm_doe.spdm_context);
+  TEEIO_ASSERT(group_context->spdm_doe.session_id);
 
-  return test_ksetgo_setup_common(group_context->doe_context, group_context->spdm_context, &group_context->session_id,
-    group_context->upper_port.mapped_kcbar_addr, group_context->stream_id, group_context->rp_stream_index,
-    group_context->upper_port.ide_id, &group_context->k_set, 0, PCIE_IDE_STREAM_KS1);
+  return test_ksetgo_setup_common(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
+    group_context->common.upper_port.mapped_kcbar_addr, group_context->stream_id, group_context->rp_stream_index,
+    group_context->common.upper_port.ide_id, &group_context->k_set, 0, PCIE_IDE_STREAM_KS1);
 }
 
 bool pcie_ide_test_ksetgo_2_run(void *test_context)
@@ -53,12 +53,12 @@ bool pcie_ide_test_ksetgo_2_run(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = (pcie_ide_test_group_context_t *)case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
   uint8_t stream_id = group_context->stream_id;
-  void *doe_context = group_context->doe_context;
-  void *spdm_context = group_context->spdm_context;
-  uint32_t session_id = group_context->session_id;
+  void *doe_context = group_context->spdm_doe.doe_context;
+  void *spdm_context = group_context->spdm_doe.spdm_context;
+  uint32_t session_id = group_context->spdm_doe.session_id;
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetGo K1|RX|PR\n"));
   status = test_ide_km_key_set_go(doe_context, spdm_context, &session_id, stream_id,
@@ -85,7 +85,7 @@ bool pcie_ide_test_ksetgo_2_run(void *test_context)
   }
 
   // set key_set_select in host ide
-  INTEL_KEYP_ROOT_COMPLEX_KCBAR *kcbar = (INTEL_KEYP_ROOT_COMPLEX_KCBAR *)group_context->upper_port.mapped_kcbar_addr;
+  INTEL_KEYP_ROOT_COMPLEX_KCBAR *kcbar = (INTEL_KEYP_ROOT_COMPLEX_KCBAR *)group_context->common.upper_port.mapped_kcbar_addr;
   set_rp_ide_key_set_select(kcbar, group_context->rp_stream_index, PCIE_IDE_STREAM_KS0);
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetGo K1|TX|PR\n"));
@@ -114,21 +114,21 @@ bool pcie_ide_test_ksetgo_2_run(void *test_context)
 
   // enable dev ide
   TEST_IDE_TYPE ide_type = TEST_IDE_TYPE_SEL_IDE;
-  if (group_context->top->type == IDE_TEST_TOPOLOGY_TYPE_LINK_IDE)
+  if (group_context->common.top->type == IDE_TEST_TOPOLOGY_TYPE_LINK_IDE)
   {
     ide_type = IDE_TEST_TOPOLOGY_TYPE_LINK_IDE;
   }
-  else if(group_context->top->type == IDE_TEST_TOPOLOGY_TYPE_SEL_LINK_IDE)
+  else if(group_context->common.top->type == IDE_TEST_TOPOLOGY_TYPE_SEL_LINK_IDE)
   {
     NOT_IMPLEMENTED("selective_and_link_ide topoplogy");
   }
-  enable_ide_stream_in_ecap(group_context->lower_port.cfg_space_fd, group_context->lower_port.ecap_offset, ide_type, group_context->lower_port.ide_id, true);
+  enable_ide_stream_in_ecap(group_context->common.lower_port.cfg_space_fd, group_context->common.lower_port.ecap_offset, ide_type, group_context->common.lower_port.ide_id, true);
 
   // enable host ide stream
-  enable_rootport_ide_stream(group_context->upper_port.cfg_space_fd,
-                         group_context->upper_port.ecap_offset,
-                         ide_type, group_context->upper_port.ide_id,
-                         group_context->upper_port.mapped_kcbar_addr,
+  enable_rootport_ide_stream(group_context->common.upper_port.cfg_space_fd,
+                         group_context->common.upper_port.ecap_offset,
+                         ide_type, group_context->common.upper_port.ide_id,
+                         group_context->common.upper_port.mapped_kcbar_addr,
                          group_context->rp_stream_index, true);
 
   res = true;

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_3.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_3.c
@@ -37,16 +37,16 @@ bool pcie_ide_test_ksetgo_3_setup(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
-  ide_common_test_port_context_t* upper_port = &group_context->upper_port;
-  ide_common_test_port_context_t* lower_port = &group_context->lower_port;
+  ide_common_test_port_context_t* upper_port = &group_context->common.upper_port;
+  ide_common_test_port_context_t* lower_port = &group_context->common.lower_port;
 
   // first setup ide_stream for KS0 (skip ksetgo)
-  bool res = setup_ide_stream(group_context->doe_context, group_context->spdm_context, &group_context->session_id,
+  bool res = setup_ide_stream(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id, PCI_IDE_KM_KEY_SET_K0,
                           &group_context->k_set, group_context->rp_stream_index,
-                          0, group_context->top->type,
+                          0, group_context->common.top->type,
                           upper_port, lower_port, true);
   if(!res) {
     return false;
@@ -239,30 +239,30 @@ bool pcie_ide_test_ksetgo_3_run(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = (pcie_ide_test_group_context_t *)case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
   uint8_t stream_id = group_context->stream_id;
-  void *doe_context = group_context->doe_context;
-  void *spdm_context = group_context->spdm_context;
-  uint32_t session_id = group_context->session_id;
+  void *doe_context = group_context->spdm_doe.doe_context;
+  void *spdm_context = group_context->spdm_doe.spdm_context;
+  uint32_t session_id = group_context->spdm_doe.session_id;
 
-  ide_common_test_port_context_t* upper_port = &group_context->upper_port;
-  ide_common_test_port_context_t* lower_port = &group_context->lower_port;
+  ide_common_test_port_context_t* upper_port = &group_context->common.upper_port;
+  ide_common_test_port_context_t* lower_port = &group_context->common.lower_port;
 
   // phase 1
   res = test_ksetgo_3_run_phase1(doe_context, spdm_context, &session_id,
                                 stream_id, group_context->rp_stream_index,
-                                upper_port->mapped_kcbar_addr, group_context->top->type,
+                                upper_port->mapped_kcbar_addr, group_context->common.top->type,
                                 upper_port, lower_port);
   if(!res) {
     goto Done;
   }
 
   // then switch to KS1 (skip ksetgo)
-  res = ide_key_switch_to(group_context->doe_context, group_context->spdm_context, &group_context->session_id,
+  res = ide_key_switch_to(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id,
                           &group_context->k_set, group_context->rp_stream_index,
-                          0, group_context->top->type, upper_port, lower_port, PCIE_IDE_STREAM_KS1, true);
+                          0, group_context->common.top->type, upper_port, lower_port, PCIE_IDE_STREAM_KS1, true);
   if(!res) {
     goto Done;
   }
@@ -270,7 +270,7 @@ bool pcie_ide_test_ksetgo_3_run(void *test_context)
   // phase 2
   res = test_ksetgo_3_run_phase2(doe_context, spdm_context, &session_id,
                                 stream_id, group_context->rp_stream_index, upper_port->ide_id,
-                                upper_port->mapped_kcbar_addr, group_context->top->type);
+                                upper_port->mapped_kcbar_addr, group_context->common.top->type);
 
 Done:
   case_context->result = res ? IDE_COMMON_TEST_CASE_RESULT_SUCCESS : IDE_COMMON_TEST_CASE_RESULT_FAILED;

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_4.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_4.c
@@ -37,16 +37,16 @@ bool pcie_ide_test_ksetgo_4_setup(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
-  ide_common_test_port_context_t* upper_port = &group_context->upper_port;
-  ide_common_test_port_context_t* lower_port = &group_context->lower_port;
+  ide_common_test_port_context_t* upper_port = &group_context->common.upper_port;
+  ide_common_test_port_context_t* lower_port = &group_context->common.lower_port;
 
   // first setup ide_stream for KS1 (skip ksetgo)
-  bool res = setup_ide_stream(group_context->doe_context, group_context->spdm_context, &group_context->session_id,
+  bool res = setup_ide_stream(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id, PCI_IDE_KM_KEY_SET_K1,
                           &group_context->k_set, group_context->rp_stream_index,
-                          0, group_context->top->type, upper_port, lower_port, true);
+                          0, group_context->common.top->type, upper_port, lower_port, true);
   if(!res) {
     return false;
   }
@@ -238,30 +238,30 @@ bool pcie_ide_test_ksetgo_4_run(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = (pcie_ide_test_group_context_t *)case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
   uint8_t stream_id = group_context->stream_id;
-  void *doe_context = group_context->doe_context;
-  void *spdm_context = group_context->spdm_context;
-  uint32_t session_id = group_context->session_id;
+  void *doe_context = group_context->spdm_doe.doe_context;
+  void *spdm_context = group_context->spdm_doe.spdm_context;
+  uint32_t session_id = group_context->spdm_doe.session_id;
 
-  ide_common_test_port_context_t* upper_port = &group_context->upper_port;
-  ide_common_test_port_context_t* lower_port = &group_context->lower_port;
+  ide_common_test_port_context_t* upper_port = &group_context->common.upper_port;
+  ide_common_test_port_context_t* lower_port = &group_context->common.lower_port;
 
   // phase 1
   res = test_ksetgo_4_run_phase1(doe_context, spdm_context, &session_id,
                                 stream_id, group_context->rp_stream_index,
-                                upper_port->mapped_kcbar_addr, group_context->top->type,
+                                upper_port->mapped_kcbar_addr, group_context->common.top->type,
                                 upper_port, lower_port);
   if(!res) {
     goto Done;
   }
 
   // then switch to KS0 (skip ksetgo)
-  res = ide_key_switch_to(group_context->doe_context, group_context->spdm_context, &group_context->session_id,
+  res = ide_key_switch_to(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id,
                           &group_context->k_set, group_context->rp_stream_index,
-                          0, group_context->top->type, upper_port, lower_port,
+                          0, group_context->common.top->type, upper_port, lower_port,
                           PCIE_IDE_STREAM_KS0, true);
   if(!res) {
     goto Done;
@@ -270,7 +270,7 @@ bool pcie_ide_test_ksetgo_4_run(void *test_context)
   // phase 2
   res = test_ksetgo_4_run_phase2(doe_context, spdm_context, &session_id,
                                 stream_id, group_context->rp_stream_index, upper_port->ide_id,
-                                upper_port->mapped_kcbar_addr, group_context->top->type);
+                                upper_port->mapped_kcbar_addr, group_context->common.top->type);
 
 Done:
   case_context->result = res ? IDE_COMMON_TEST_CASE_RESULT_SUCCESS : IDE_COMMON_TEST_CASE_RESULT_FAILED;

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_1.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_1.c
@@ -110,15 +110,15 @@ bool pcie_ide_test_ksetstop_1_setup(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
-  ide_common_test_port_context_t* upper_port = &group_context->upper_port;
-  ide_common_test_port_context_t* lower_port = &group_context->lower_port;
+  ide_common_test_port_context_t* upper_port = &group_context->common.upper_port;
+  ide_common_test_port_context_t* lower_port = &group_context->common.lower_port;
 
-  return setup_ide_stream(group_context->doe_context, group_context->spdm_context, &group_context->session_id,
+  return setup_ide_stream(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id, PCI_IDE_KM_KEY_SET_K0,
                           &group_context->k_set, group_context->rp_stream_index,
-                          0, group_context->top->type, upper_port, lower_port, false);
+                          0, group_context->common.top->type, upper_port, lower_port, false);
 
 }
 
@@ -131,12 +131,12 @@ bool pcie_ide_test_ksetstop_1_run(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
-  ide_common_test_port_context_t* upper_port = &group_context->upper_port;
-  ide_common_test_port_context_t* lower_port = &group_context->lower_port;
+  ide_common_test_port_context_t* upper_port = &group_context->common.upper_port;
+  ide_common_test_port_context_t* lower_port = &group_context->common.lower_port;
 
-  IDE_TEST_TOPOLOGY_TYPE top_type = group_context->top->type;
+  IDE_TEST_TOPOLOGY_TYPE top_type = group_context->common.top->type;
 
   // disable dev ide
   TEST_IDE_TYPE ide_type = TEST_IDE_TYPE_SEL_IDE;
@@ -157,9 +157,9 @@ bool pcie_ide_test_ksetstop_1_run(void *test_context)
                          upper_port->mapped_kcbar_addr,
                          group_context->rp_stream_index, false);
 
-  void* doe_context = group_context->doe_context;
-  void* spdm_context = group_context->spdm_context;
-  uint32_t session_id = group_context->session_id;
+  void* doe_context = group_context->spdm_doe.doe_context;
+  void* spdm_context = group_context->spdm_doe.spdm_context;
+  uint32_t session_id = group_context->spdm_doe.session_id;
   uint8_t stream_id = group_context->stream_id;
   uint8_t ks = PCI_IDE_KM_KEY_SET_K0;
   uint8_t port_index = 0;

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_2.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_2.c
@@ -31,15 +31,15 @@ bool pcie_ide_test_ksetstop_2_setup(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
-  ide_common_test_port_context_t* upper_port = &group_context->upper_port;
-  ide_common_test_port_context_t* lower_port = &group_context->lower_port;
+  ide_common_test_port_context_t* upper_port = &group_context->common.upper_port;
+  ide_common_test_port_context_t* lower_port = &group_context->common.lower_port;
 
-  return setup_ide_stream(group_context->doe_context, group_context->spdm_context, &group_context->session_id,
+  return setup_ide_stream(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id, PCI_IDE_KM_KEY_SET_K1,
                           &group_context->k_set, group_context->rp_stream_index,
-                          0, group_context->top->type, upper_port, lower_port, false);
+                          0, group_context->common.top->type, upper_port, lower_port, false);
 
 }
 
@@ -52,12 +52,12 @@ bool pcie_ide_test_ksetstop_2_run(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
-  ide_common_test_port_context_t* upper_port = &group_context->upper_port;
-  ide_common_test_port_context_t* lower_port = &group_context->lower_port;
+  ide_common_test_port_context_t* upper_port = &group_context->common.upper_port;
+  ide_common_test_port_context_t* lower_port = &group_context->common.lower_port;
 
-  IDE_TEST_TOPOLOGY_TYPE top_type = group_context->top->type;
+  IDE_TEST_TOPOLOGY_TYPE top_type = group_context->common.top->type;
 
   // disable dev ide
   TEST_IDE_TYPE ide_type = TEST_IDE_TYPE_SEL_IDE;
@@ -78,9 +78,9 @@ bool pcie_ide_test_ksetstop_2_run(void *test_context)
                          upper_port->mapped_kcbar_addr,
                          group_context->rp_stream_index, false);
 
-  void* doe_context = group_context->doe_context;
-  void* spdm_context = group_context->spdm_context;
-  uint32_t session_id = group_context->session_id;
+  void* doe_context = group_context->spdm_doe.doe_context;
+  void* spdm_context = group_context->spdm_doe.spdm_context;
+  uint32_t session_id = group_context->spdm_doe.session_id;
   uint8_t stream_id = group_context->stream_id;
   uint8_t port_index = 0;
   bool res = false;

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_3.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_3.c
@@ -31,25 +31,25 @@ bool pcie_ide_test_ksetstop_3_setup(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
-  ide_common_test_port_context_t* upper_port = &group_context->upper_port;
-  ide_common_test_port_context_t* lower_port = &group_context->lower_port;
+  ide_common_test_port_context_t* upper_port = &group_context->common.upper_port;
+  ide_common_test_port_context_t* lower_port = &group_context->common.lower_port;
 
   // first setup ide_stream for KS0
-  bool res = setup_ide_stream(group_context->doe_context, group_context->spdm_context, &group_context->session_id,
+  bool res = setup_ide_stream(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id, PCI_IDE_KM_KEY_SET_K0,
                           &group_context->k_set, group_context->rp_stream_index,
-                          0, group_context->top->type, upper_port, lower_port, false);
+                          0, group_context->common.top->type, upper_port, lower_port, false);
   if(!res) {
     return false;
   }
 
   // then switch to KS1
-  res = ide_key_switch_to(group_context->doe_context, group_context->spdm_context, &group_context->session_id,
+  res = ide_key_switch_to(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id,
                           &group_context->k_set, group_context->rp_stream_index,
-                          0, group_context->top->type, upper_port, lower_port, PCIE_IDE_STREAM_KS1, false);
+                          0, group_context->common.top->type, upper_port, lower_port, PCIE_IDE_STREAM_KS1, false);
 
   return res;
 }
@@ -62,12 +62,12 @@ bool pcie_ide_test_ksetstop_3_run(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
-  ide_common_test_port_context_t* upper_port = &group_context->upper_port;
-  ide_common_test_port_context_t* lower_port = &group_context->lower_port;
+  ide_common_test_port_context_t* upper_port = &group_context->common.upper_port;
+  ide_common_test_port_context_t* lower_port = &group_context->common.lower_port;
 
-  IDE_TEST_TOPOLOGY_TYPE top_type = group_context->top->type;
+  IDE_TEST_TOPOLOGY_TYPE top_type = group_context->common.top->type;
 
   // disable dev ide
   TEST_IDE_TYPE ide_type = TEST_IDE_TYPE_SEL_IDE;
@@ -88,9 +88,9 @@ bool pcie_ide_test_ksetstop_3_run(void *test_context)
                          upper_port->mapped_kcbar_addr,
                          group_context->rp_stream_index, false);
 
-  void* doe_context = group_context->doe_context;
-  void* spdm_context = group_context->spdm_context;
-  uint32_t session_id = group_context->session_id;
+  void* doe_context = group_context->spdm_doe.doe_context;
+  void* spdm_context = group_context->spdm_doe.spdm_context;
+  uint32_t session_id = group_context->spdm_doe.session_id;
   uint8_t stream_id = group_context->stream_id;
   uint8_t port_index = 0;
   bool res = false;

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_4.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_4.c
@@ -31,25 +31,25 @@ bool pcie_ide_test_ksetstop_4_setup(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
-  ide_common_test_port_context_t* upper_port = &group_context->upper_port;
-  ide_common_test_port_context_t* lower_port = &group_context->lower_port;
+  ide_common_test_port_context_t* upper_port = &group_context->common.upper_port;
+  ide_common_test_port_context_t* lower_port = &group_context->common.lower_port;
 
   // first setup ide_stream for KS1
-  bool res = setup_ide_stream(group_context->doe_context, group_context->spdm_context, &group_context->session_id,
+  bool res = setup_ide_stream(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id, PCI_IDE_KM_KEY_SET_K1,
                           &group_context->k_set, group_context->rp_stream_index,
-                          0, group_context->top->type, upper_port, lower_port, false);
+                          0, group_context->common.top->type, upper_port, lower_port, false);
   if(!res) {
     return false;
   }
 
   // then switch to KS0
-  res = ide_key_switch_to(group_context->doe_context, group_context->spdm_context, &group_context->session_id,
+  res = ide_key_switch_to(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id,
                           &group_context->k_set, group_context->rp_stream_index,
-                          0, group_context->top->type,
+                          0, group_context->common.top->type,
                           upper_port, lower_port,
                           PCI_IDE_KM_KEY_SET_K0, false);
 
@@ -64,12 +64,12 @@ bool pcie_ide_test_ksetstop_4_run(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
-  ide_common_test_port_context_t* upper_port = &group_context->upper_port;
-  ide_common_test_port_context_t* lower_port = &group_context->lower_port;
+  ide_common_test_port_context_t* upper_port = &group_context->common.upper_port;
+  ide_common_test_port_context_t* lower_port = &group_context->common.lower_port;
 
-  IDE_TEST_TOPOLOGY_TYPE top_type = group_context->top->type;
+  IDE_TEST_TOPOLOGY_TYPE top_type = group_context->common.top->type;
 
   // disable dev ide
   TEST_IDE_TYPE ide_type = TEST_IDE_TYPE_SEL_IDE;
@@ -90,9 +90,9 @@ bool pcie_ide_test_ksetstop_4_run(void *test_context)
                          upper_port->mapped_kcbar_addr,
                          group_context->rp_stream_index, false);
 
-  void* doe_context = group_context->doe_context;
-  void* spdm_context = group_context->spdm_context;
-  uint32_t session_id = group_context->session_id;
+  void* doe_context = group_context->spdm_doe.doe_context;
+  void* spdm_context = group_context->spdm_doe.spdm_context;
+  uint32_t session_id = group_context->spdm_doe.session_id;
   uint8_t stream_id = group_context->stream_id;
   uint8_t port_index = 0;
   bool res = false;

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_query.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_query.c
@@ -165,21 +165,21 @@ bool pcie_ide_test_query_1_run(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
-  TEEIO_ASSERT(group_context->spdm_context);
-  TEEIO_ASSERT(group_context->session_id);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->spdm_doe.spdm_context);
+  TEEIO_ASSERT(group_context->spdm_doe.session_id);
 
   uint8_t port_index = 0;
-  uint8_t dev_func = ((group_context->lower_port.port->device & 0x1f) << 3) | (group_context->lower_port.port->function & 0x7);
-  uint8_t bus = group_context->lower_port.port->bus;
+  uint8_t dev_func = ((group_context->common.lower_port.port->device & 0x1f) << 3) | (group_context->common.lower_port.port->function & 0x7);
+  uint8_t bus = group_context->common.lower_port.port->bus;
   uint8_t segment = 0;
   uint8_t max_port_index = 0;
   uint32_t ide_reg_block[PCI_IDE_KM_IDE_REG_BLOCK_SUPPORTED_COUNT] = {0};
   uint32_t ide_reg_block_count = PCI_IDE_KM_IDE_REG_BLOCK_SUPPORTED_COUNT;
 
-  libspdm_return_t status = test_pci_ide_km_query(group_context->doe_context,
-                                                  group_context->spdm_context,
-                                                  &group_context->session_id,
+  libspdm_return_t status = test_pci_ide_km_query(group_context->spdm_doe.doe_context,
+                                                  group_context->spdm_doe.spdm_context,
+                                                  &group_context->spdm_doe.session_id,
                                                   port_index, &dev_func, &bus, &segment,
                                                   &max_port_index, ide_reg_block, &ide_reg_block_count,
                                                   true, "Assertion 1.1");
@@ -203,20 +203,20 @@ bool pcie_ide_test_query_2_setup(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
-  TEEIO_ASSERT(group_context->spdm_context);
-  TEEIO_ASSERT(group_context->session_id);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->spdm_doe.spdm_context);
+  TEEIO_ASSERT(group_context->spdm_doe.session_id);
 
   uint8_t port_index = 0;
-  uint8_t dev_func = ((group_context->lower_port.port->device & 0x1f) << 3) | (group_context->lower_port.port->function & 0x7);
-  uint8_t bus = group_context->lower_port.port->bus;
+  uint8_t dev_func = ((group_context->common.lower_port.port->device & 0x1f) << 3) | (group_context->common.lower_port.port->function & 0x7);
+  uint8_t bus = group_context->common.lower_port.port->bus;
   uint8_t segment = 0;
   uint8_t max_port_index = 0;
   uint32_t ide_reg_block[PCI_IDE_KM_IDE_REG_BLOCK_SUPPORTED_COUNT] = {0};
   uint32_t ide_reg_block_count = PCI_IDE_KM_IDE_REG_BLOCK_SUPPORTED_COUNT;
 
-  libspdm_return_t status = test_pci_ide_km_query(group_context->doe_context,
-                                                  group_context->spdm_context, &group_context->session_id,
+  libspdm_return_t status = test_pci_ide_km_query(group_context->spdm_doe.doe_context,
+                                                  group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
                                                   port_index, &dev_func, &bus, &segment,
                                                   &max_port_index, ide_reg_block, &ide_reg_block_count,
                                                   false, "");
@@ -245,21 +245,21 @@ bool pcie_ide_test_query_2_run(void *test_context)
 
   pcie_ide_test_group_context_t *group_context = case_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
-  TEEIO_ASSERT(group_context->spdm_context);
-  TEEIO_ASSERT(group_context->session_id);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->spdm_doe.spdm_context);
+  TEEIO_ASSERT(group_context->spdm_doe.session_id);
 
   uint8_t port_index = mMaxPortIndex;
-  uint8_t dev_func = ((group_context->lower_port.port->device & 0x1f) << 3) | (group_context->lower_port.port->function & 0x7);
-  uint8_t bus = group_context->lower_port.port->bus;
+  uint8_t dev_func = ((group_context->common.lower_port.port->device & 0x1f) << 3) | (group_context->common.lower_port.port->function & 0x7);
+  uint8_t bus = group_context->common.lower_port.port->bus;
   uint8_t segment = 0;
   uint8_t max_port_index = 0;
   uint32_t ide_reg_block[PCI_IDE_KM_IDE_REG_BLOCK_SUPPORTED_COUNT] = {0};
   uint32_t ide_reg_block_count = PCI_IDE_KM_IDE_REG_BLOCK_SUPPORTED_COUNT;
 
-  libspdm_return_t status = test_pci_ide_km_query(group_context->doe_context,
-                                                  group_context->spdm_context,
-                                                  &group_context->session_id,
+  libspdm_return_t status = test_pci_ide_km_query(group_context->spdm_doe.doe_context,
+                                                  group_context->spdm_doe.spdm_context,
+                                                  &group_context->spdm_doe.session_id,
                                                   port_index, &dev_func, &bus, &segment,
                                                   &max_port_index, ide_reg_block, &ide_reg_block_count,
                                                   true, "Assertion 2.1");

--- a/teeio-validator/library/pcie_ide_test_lib/test_config/test_config_common.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_config/test_config_common.c
@@ -42,15 +42,15 @@ bool test_config_check_common(void *test_context, const char* assertion_msg)
 
   pcie_ide_test_group_context_t *group_context = (pcie_ide_test_group_context_t *)config_context->group_context;
   TEEIO_ASSERT(group_context);
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
-  ide_common_test_port_context_t *port = &group_context->upper_port;
+  ide_common_test_port_context_t *port = &group_context->common.upper_port;
   TEST_IDE_TYPE ide_type = TEST_IDE_TYPE_SEL_IDE;
-  if (group_context->top->type == IDE_TEST_TOPOLOGY_TYPE_LINK_IDE)
+  if (group_context->common.top->type == IDE_TEST_TOPOLOGY_TYPE_LINK_IDE)
   {
     ide_type = TEST_IDE_TYPE_LNK_IDE;
   }
-  else if(group_context->top->type == IDE_TEST_TOPOLOGY_TYPE_SEL_LINK_IDE)
+  else if(group_context->common.top->type == IDE_TEST_TOPOLOGY_TYPE_SEL_LINK_IDE)
   {
     NOT_IMPLEMENTED("selective_and_link_ide topology");
   }
@@ -131,8 +131,8 @@ static bool test_config_reset_ide_registers(pcie_ide_test_group_context_t *group
   bool res;
 
   // reset ide registers
-  res = reset_ide_registers(&group_context->upper_port,
-                            group_context->top->type,
+  res = reset_ide_registers(&group_context->common.upper_port,
+                            group_context->common.top->type,
                             group_context->stream_id,
                             group_context->rp_stream_index,
                             true);
@@ -142,8 +142,8 @@ static bool test_config_reset_ide_registers(pcie_ide_test_group_context_t *group
     return false;
   }
 
-  res = reset_ide_registers(&group_context->lower_port,
-                            group_context->top->type,
+  res = reset_ide_registers(&group_context->common.lower_port,
+                            group_context->common.top->type,
                             group_context->stream_id,
                             group_context->rp_stream_index,
                             false);
@@ -163,12 +163,12 @@ bool test_config_enable_common(void *test_context)
   TEEIO_ASSERT(config_context->signature == CONFIG_CONTEXT_SIGNATURE);
 
   pcie_ide_test_group_context_t *group_context = config_context->group_context;
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
   // if connection is via switch or P2P, then we shall set ft_supported in the switch's port
   ide_common_test_switch_internal_conn_context_t* conn;
-  if(group_context->top->connection == IDE_TEST_CONNECT_SWITCH || group_context->top->connection == IDE_TEST_CONNECT_P2P) {
-    conn = group_context->sw_conn1;
+  if(group_context->common.top->connection == IDE_TEST_CONNECT_SWITCH || group_context->common.top->connection == IDE_TEST_CONNECT_P2P) {
+    conn = group_context->common.sw_conn1;
     TEEIO_ASSERT(conn);
 
     res = true;
@@ -182,8 +182,8 @@ bool test_config_enable_common(void *test_context)
     return false;
   }
 
-  if(group_context->top->connection == IDE_TEST_CONNECT_P2P) {
-    conn = group_context->sw_conn2;
+  if(group_context->common.top->connection == IDE_TEST_CONNECT_P2P) {
+    conn = group_context->common.sw_conn2;
     TEEIO_ASSERT(conn);
     res = true;
     while(res && conn) {
@@ -256,17 +256,17 @@ bool test_config_support_common(void *test_context)
   TEEIO_ASSERT(config_context->signature == CONFIG_CONTEXT_SIGNATURE);
 
   pcie_ide_test_group_context_t *group_context = config_context->group_context;
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
-  PCIE_IDE_CAP *host_cap = &group_context->upper_port.ide_cap;
-  PCIE_IDE_CAP *dev_cap = &group_context->lower_port.ide_cap;
+  PCIE_IDE_CAP *host_cap = &group_context->common.upper_port.ide_cap;
+  PCIE_IDE_CAP *dev_cap = &group_context->common.lower_port.ide_cap;
 
   bool supported = false;
-  if(group_context->top->type == IDE_TEST_TOPOLOGY_TYPE_SEL_IDE) {
+  if(group_context->common.top->type == IDE_TEST_TOPOLOGY_TYPE_SEL_IDE) {
     supported = host_cap->sel_ide_supported == 1 && dev_cap->sel_ide_supported == 1;
-  } else if(group_context->top->type == IDE_TEST_TOPOLOGY_TYPE_LINK_IDE) {
+  } else if(group_context->common.top->type == IDE_TEST_TOPOLOGY_TYPE_LINK_IDE) {
     supported = host_cap->sel_ide_supported == 1 && dev_cap->sel_ide_supported == 1;
-  } else if(group_context->top->type == IDE_TEST_TOPOLOGY_TYPE_SEL_LINK_IDE) {
+  } else if(group_context->common.top->type == IDE_TEST_TOPOLOGY_TYPE_SEL_LINK_IDE) {
     supported = host_cap->sel_ide_supported == 1 && dev_cap->sel_ide_supported == 1 && host_cap->sel_ide_supported == 1 && dev_cap->sel_ide_supported == 1;
   }
 
@@ -280,8 +280,8 @@ bool test_config_support_common(void *test_context)
 
   // check ft_supported if it is via switch
   ide_common_test_switch_internal_conn_context_t* conn;
-  if(group_context->top->connection == IDE_TEST_CONNECT_SWITCH || group_context->top->connection == IDE_TEST_CONNECT_P2P) {
-    conn = group_context->sw_conn1;
+  if(group_context->common.top->connection == IDE_TEST_CONNECT_SWITCH || group_context->common.top->connection == IDE_TEST_CONNECT_P2P) {
+    conn = group_context->common.sw_conn1;
     TEEIO_ASSERT(conn);
 
     supported = true;
@@ -303,8 +303,8 @@ bool test_config_support_common(void *test_context)
     return false;
   }
 
-  if(group_context->top->connection == IDE_TEST_CONNECT_P2P) {
-    conn = group_context->sw_conn2;;
+  if(group_context->common.top->connection == IDE_TEST_CONNECT_P2P) {
+    conn = group_context->common.sw_conn2;;
     TEEIO_ASSERT(conn);
 
     supported = true;

--- a/teeio-validator/library/pcie_ide_test_lib/test_config/test_config_pcrc.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_config/test_config_pcrc.c
@@ -25,11 +25,11 @@ static bool test_config_set_pcrc_common(void *test_context, bool enable)
   TEEIO_ASSERT(config_context->signature == CONFIG_CONTEXT_SIGNATURE);
 
   pcie_ide_test_group_context_t *group_context = config_context->group_context;
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
   // enable pcrc bit in
   TEST_IDE_TYPE ide_type = TEST_IDE_TYPE_SEL_IDE;
-  IDE_TEST_TOPOLOGY *top = group_context->top;
+  IDE_TEST_TOPOLOGY *top = group_context->common.top;
   if(top->type == IDE_TEST_TOPOLOGY_TYPE_LINK_IDE) {
     ide_type = TEST_IDE_TYPE_LNK_IDE;
   } else if (top->type == IDE_TEST_TOPOLOGY_TYPE_SEL_LINK_IDE){
@@ -38,9 +38,9 @@ static bool test_config_set_pcrc_common(void *test_context, bool enable)
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "%s pcrc for %s\n", enable ? "enable" : "disable", m_ide_test_topology_name[top->type]));
 
-  ide_common_test_port_context_t *port_context = &group_context->upper_port;
+  ide_common_test_port_context_t *port_context = &group_context->common.upper_port;
   set_pcrc_in_ecap(port_context->cfg_space_fd, ide_type, port_context->ide_id, port_context->ecap_offset, enable);
-  port_context = &group_context->lower_port;
+  port_context = &group_context->common.lower_port;
   set_pcrc_in_ecap(port_context->cfg_space_fd, ide_type, port_context->ide_id, port_context->ecap_offset, enable);
 
   return true;
@@ -52,10 +52,10 @@ static bool test_config_check_pcrc_support_common(void *test_context)
   TEEIO_ASSERT(config_context->signature == CONFIG_CONTEXT_SIGNATURE);
 
   pcie_ide_test_group_context_t *group_context = config_context->group_context;
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
-  PCIE_IDE_CAP *host_cap = &group_context->upper_port.ide_cap;
-  PCIE_IDE_CAP *dev_cap = &group_context->lower_port.ide_cap;
+  PCIE_IDE_CAP *host_cap = &group_context->common.upper_port.ide_cap;
+  PCIE_IDE_CAP *dev_cap = &group_context->common.lower_port.ide_cap;
   if(!host_cap->pcrc_supported || !dev_cap->pcrc_supported) {
     TEEIO_DEBUG((TEEIO_DEBUG_WARN, "check pcrc and it is NOT supported. host=%d, device=%d\n", host_cap->pcrc_supported, dev_cap->pcrc_supported));
     return false;

--- a/teeio-validator/library/pcie_ide_test_lib/test_config/test_config_sel_ide_for_cfg_req.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_config/test_config_sel_ide_for_cfg_req.c
@@ -35,19 +35,19 @@ static bool test_config_set_sel_ide_for_cfg_req(void* test_context, bool enable)
   TEEIO_ASSERT(config_context->signature == CONFIG_CONTEXT_SIGNATURE);
 
   pcie_ide_test_group_context_t *group_context = config_context->group_context;
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
-  TEST_IDE_TYPE ide_type = map_top_type_to_ide_type(group_context->top->type);
+  TEST_IDE_TYPE ide_type = map_top_type_to_ide_type(group_context->common.top->type);
 
   // enable cfg_sel_ide bit in upper port and lower port
-  ide_common_test_port_context_t* port_context = &group_context->upper_port;
+  ide_common_test_port_context_t* port_context = &group_context->common.upper_port;
   set_sel_ide_for_cfg_req_in_ecap(port_context->cfg_space_fd,
                           ide_type,
                           port_context->ide_id,
                           port_context->ecap_offset,
                           enable);
 
-  port_context = &group_context->lower_port;
+  port_context = &group_context->common.lower_port;
   set_sel_ide_for_cfg_req_in_ecap(port_context->cfg_space_fd,
                           ide_type,
                           port_context->ide_id,
@@ -66,16 +66,16 @@ static bool test_config_check_sel_ide_for_cfg_req_support(void* test_context)
   TEEIO_ASSERT(config_context->signature == CONFIG_CONTEXT_SIGNATURE);
 
   pcie_ide_test_group_context_t *group_context = config_context->group_context;
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
-  TEST_IDE_TYPE ide_type = map_top_type_to_ide_type(group_context->top->type);
+  TEST_IDE_TYPE ide_type = map_top_type_to_ide_type(group_context->common.top->type);
   if(ide_type != TEST_IDE_TYPE_SEL_IDE) {
     TEEIO_DEBUG((TEEIO_DEBUG_ERROR, "\"%s\" is not avaible in %s\n", m_config_name, m_ide_type_name[ide_type]));
     return false;    
   }
 
-  PCIE_IDE_CAP *upper_cap = &group_context->upper_port.ide_cap;
-  PCIE_IDE_CAP *lower_cap = &group_context->lower_port.ide_cap;
+  PCIE_IDE_CAP *upper_cap = &group_context->common.upper_port.ide_cap;
+  PCIE_IDE_CAP *lower_cap = &group_context->common.lower_port.ide_cap;
   bool supported = upper_cap->sel_ide_cfg_req_supported && lower_cap->sel_ide_cfg_req_supported;
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "%s is %s.\n", m_config_name, supported ? "supported" : "NOT supported"));
   return supported;
@@ -103,18 +103,18 @@ bool pcie_ide_test_config_check_sel_ide_for_cfg_req(void *test_context)
   TEEIO_ASSERT(config_context->signature == CONFIG_CONTEXT_SIGNATURE);
 
   pcie_ide_test_group_context_t *group_context = config_context->group_context;
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
-  TEST_IDE_TYPE ide_type = map_top_type_to_ide_type(group_context->top->type);
+  TEST_IDE_TYPE ide_type = map_top_type_to_ide_type(group_context->common.top->type);
   TEEIO_ASSERT(ide_type == TEST_IDE_TYPE_SEL_IDE);
 
-  ide_common_test_port_context_t* port_context = &group_context->upper_port;
+  ide_common_test_port_context_t* port_context = &group_context->common.upper_port;
   uint32_t data1 =read_ide_stream_ctrl_in_ecap(port_context->cfg_space_fd,
                           ide_type,
                           port_context->ide_id,
                           port_context->ecap_offset);
 
-  port_context = &group_context->lower_port;
+  port_context = &group_context->common.lower_port;
   uint32_t data2 = read_ide_stream_ctrl_in_ecap(port_context->cfg_space_fd,
                           ide_type,
                           port_context->ide_id,

--- a/teeio-validator/teeio_validator/ide_test.c
+++ b/teeio-validator/teeio_validator/ide_test.c
@@ -533,7 +533,7 @@ bool do_run_test_case(ide_run_test_case_t *test_case, ide_run_test_case_result_t
   TEEIO_ASSERT(case_context->signature == CASE_CONTEXT_SIGNATURE);
 
   pcie_ide_test_group_context_t *group_context = (pcie_ide_test_group_context_t *)case_context->group_context;
-  TEEIO_ASSERT(group_context->signature == GROUP_CONTEXT_SIGNATURE);
+  TEEIO_ASSERT(group_context->common.signature == GROUP_CONTEXT_SIGNATURE);
 
   TEEIO_PRINT(("     Run %s\n", test_case->name));
 


### PR DESCRIPTION
There are duplicated parts in pcie_ide_test_group_context_t and cxl_ide_test_group_context_t. This patch refactors the 2 structs by moving the duplicated parts into 2 context:
 - teeio_common_test_group_context_t
 - spdm_doe_context_t

This makes the code more clear and easy to  understand.