### PR TITLE
Remove the "ide_stream_secure - na" from result summary

### DIFF
--- a/teeio-validator/teeio_validator/ide_test.c
+++ b/teeio-validator/teeio_validator/ide_test.c
@@ -947,7 +947,7 @@ bool print_test_results(ide_run_test_suite_t *run_test_suite)
         TEEIO_PRINT(("     TestGroup (%s %s) - pass: %d, fail: %d, skip: %d\n", group_result->name, case_result->class, passed, failed, skipped));
 
         while(case_result) {
-          TEEIO_PRINT(("       %s: case - %s; ide_stream_secure - %s\n", case_result->name, m_test_case_result_str[case_result->case_result], m_test_config_result_str[case_result->config_result]));
+          TEEIO_PRINT(("       %s: case - %s\n", case_result->name, m_test_case_result_str[case_result->case_result]));
 
           case_result = case_result->next;
         }


### PR DESCRIPTION
Fix #193 

After fix, the result summary looks like below:
```
Print test results.
TestSuite_1 - pass: 7, fail: 0, skip: 1
  TestConfiguration (default)
    TestGroup (SelectiveIDE Query) - pass: 1, fail: 0, skip: 1
      Query.1: case - pass
      Query.2: case - skip

    TestGroup (SelectiveIDE KeyProg) - pass: 6, fail: 0, skip: 0
      KeyProg.1: case - pass
      KeyProg.2: case - pass
      KeyProg.3: case - pass
      KeyProg.4: case - pass
      KeyProg.5: case - pass
      KeyProg.6: case - pass
```