### PR TITLE
Call pcie_ide_teardown_common in PCIE IDE KSetGo teardown functions

### DIFF
--- a/teeio-validator/library/pcie_ide_test_lib/include/pcie_ide_test_internal.h
+++ b/teeio-validator/library/pcie_ide_test_lib/include/pcie_ide_test_internal.h
@@ -103,4 +103,6 @@ bool test_pci_ide_km_key_set_stop(const void *pci_doe_context,
  */
 void pcie_dump_key_iv_in_rp(const char* direction, uint8_t *key, int key_size, uint8_t* iv, int iv_size);
 
+bool pcie_ide_teardown_common(void *test_context, uint8_t ks);
+
 #endif

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_full.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_full.c
@@ -154,7 +154,7 @@ static bool test_full_ide_km_key_set_stop(const void *pci_doe_context,
     return true;
 }
 
-bool test_full_teardown_common(void *test_context, uint8_t ks)
+bool pcie_ide_teardown_common(void *test_context, uint8_t ks)
 {
   // first diable dev_ide and host_ide
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
@@ -244,5 +244,5 @@ TestFullTeardownDone:
 
 bool pcie_ide_test_full_1_teardown(void *test_context)
 {
-  return test_full_teardown_common(test_context, PCI_IDE_KM_KEY_SET_K0);
+  return pcie_ide_teardown_common(test_context, PCI_IDE_KM_KEY_SET_K0);
 }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_full_keyrefresh.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_full_keyrefresh.c
@@ -24,8 +24,6 @@
 
 static uint8_t mKeySet = 0;
 
-bool test_full_teardown_common(void *test_context, uint8_t ks);
-
 bool pcie_ide_test_full_keyrefresh_setup(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
@@ -123,5 +121,5 @@ bool pcie_ide_test_full_keyrefresh_run(void *test_context)
 
 bool pcie_ide_test_full_keyrefresh_teardown(void *test_context)
 {
-  return test_full_teardown_common(test_context, mKeySet);
+  return pcie_ide_teardown_common(test_context, mKeySet);
 }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_1.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_1.c
@@ -328,5 +328,5 @@ Done:
 
 bool pcie_ide_test_ksetgo_1_teardown(void *test_context)
 {
-  return true;
+  return pcie_ide_teardown_common(test_context, PCI_IDE_KM_KEY_SET_K0);
 }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_2.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_2.c
@@ -144,5 +144,5 @@ Done:
 
 bool pcie_ide_test_ksetgo_2_teardown(void *test_context)
 {
-  return true;
+  return pcie_ide_teardown_common(test_context, PCI_IDE_KM_KEY_SET_K1);
 }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_3.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_3.c
@@ -280,5 +280,5 @@ Done:
 
 bool pcie_ide_test_ksetgo_3_teardown(void *test_context)
 {
-  return true;
+  return pcie_ide_teardown_common(test_context, PCI_IDE_KM_KEY_SET_K1);
 }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_4.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_4.c
@@ -280,5 +280,5 @@ Done:
 
 bool pcie_ide_test_ksetgo_4_teardown(void *test_context)
 {
-  return true;
+  return pcie_ide_teardown_common(test_context, PCI_IDE_KM_KEY_SET_K0);
 }


### PR DESCRIPTION
Fix #199 

Teardown of KSetGo test cases shall be implemented to gracefully close the PCIE IDE Stream which is setup during KSetGo test case.