### PR TITLE
Fix PCIe IDE IV print out error

### DIFF
--- a/teeio-validator/library/pcie_ide_test_lib/test_case/ide_km_common.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/ide_km_common.c
@@ -52,7 +52,7 @@ void pcie_dump_key_iv_in_rp(const char* direction, uint8_t *key, int key_size, u
   }
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "PCIe IDE IV in rootport registers (%s IV Slots):\n", direction));
-  for(i = 0; i < 8; i++) {
+  for(i = 0; i < 2; i++) {
     TEEIO_DEBUG((TEEIO_DEBUG_INFO, "  IFV_DW%d: 0x%08x\n", i, *(uint32_t *)(iv + i*4)));
   }
 }


### PR DESCRIPTION
Fix #232 

Size of PCIE IDE IV is 8 bytes. But pcie_dump_key_iv_in_rp wrongly print out 8*4 bytes.