### PR TITLE
Add test interval and rounds in PCIE-KeyRefresh

### DIFF
--- a/teeio-validator/teeio_validator/cmdline.c
+++ b/teeio-validator/teeio_validator/cmdline.c
@@ -38,6 +38,8 @@ extern bool g_libspdm_log;
 extern uint8_t g_scan_bus;
 extern bool g_run_test_suite;
 extern bool g_teeio_fixed_key;
+extern int g_test_interval;
+extern int g_test_rounds;
 
 bool is_valid_test_case(const char* test_case_name, TEEIO_TEST_CATEGORY test_category);
 
@@ -57,6 +59,8 @@ void print_usage()
   TEEIO_PRINT(("  -l <debug_level>    : Set debug level. error/warn/info/verbose\n"));
   TEEIO_PRINT(("  -b <scan_bus>       : Bus number in hex format. For example 0x1a\n"));
   TEEIO_PRINT(("  -i <test_category>  : test category. For example pcie-ide, cxl-ide, cxl-tsp\n"));
+  TEEIO_PRINT(("  -e <test_interval>  : test interval of 2 rounds.\n"));
+  TEEIO_PRINT(("  -n <test_rounds>    : test rounds of a case.\n"));
   TEEIO_PRINT(("  -k                  : Use fixed IDE Key for debug purpose.\n"));
   TEEIO_PRINT(("  -h                  : Display this usage\n"));
 }
@@ -91,7 +95,7 @@ bool parse_cmdline_option(int argc, char *argv[], char* file_name, IDE_TEST_CONF
   }
   TEEIO_PRINT(("%s\n", buf));
 
-  while ((opt = getopt(argc, argv, "f:t:c:s:l:i:b:kh")) != -1) {
+  while ((opt = getopt(argc, argv, "f:t:c:s:l:i:b:n:e:kh")) != -1) {
       switch (opt) {
           case 'f':
               if(!validate_file_name(optarg)) {
@@ -144,6 +148,24 @@ bool parse_cmdline_option(int argc, char *argv[], char* file_name, IDE_TEST_CONF
               TEEIO_DEBUG((TEEIO_DEBUG_ERROR, "Invalid -i parameter. %s\n", optarg));
               return false;
             }
+            break;
+
+        case 'n':
+            v = atoi(optarg);
+            if(v <= 0) {
+              TEEIO_DEBUG((TEEIO_DEBUG_ERROR, "Invalid -n parameter %s\n", optarg));
+              return false;
+            }
+            g_test_rounds = v;
+            break;
+
+        case 'e':
+            v = atoi(optarg);
+            if(v <= 0) {
+              TEEIO_DEBUG((TEEIO_DEBUG_ERROR, "Invalid -e parameter %s\n", optarg));
+              return false;
+            }
+            g_test_interval = v;
             break;
 
         case 'k':

--- a/teeio-validator/teeio_validator/teeio_validator.c
+++ b/teeio-validator/teeio_validator/teeio_validator.c
@@ -26,6 +26,8 @@ char g_test_case[MAX_CASE_NAME_LENGTH] = {0};
 bool g_run_test_suite = true;
 bool g_teeio_fixed_key = false;
 pci_tdisp_interface_id_t g_tdisp_interface_id = {0};
+int g_test_interval = 0;
+int g_test_rounds = 0;
 
 TEEIO_DEBUG_LEVEL g_debug_level = TEEIO_DEBUG_WARN;
 bool g_libspdm_log = false;


### PR DESCRIPTION
Fix #254 

Add 2 command options to support test interval and rounds.
```
   -e <test_interval>  : test interval of 2 rounds.
   -n <test_rounds>    : test rounds of a case.
```

Sample command options looks like:

```
## To test KeyRefresh 5 rounds. Interval of each rounds is 10 seconds.
./teeio_validator -f selective_ide_x4x4x4x4_direct.ini -t 1 -c 1 -e 10 -n 5 -s Test.KeyRefresh
```