### PR TITLE
Refine CXL KeyProg Case 3/4/5

### DIFF
--- a/teeio-validator/include/helperlib.h
+++ b/teeio-validator/include/helperlib.h
@@ -18,6 +18,8 @@
 
 void libspdm_sleep(uint64_t microseconds);
 
+bool is_power_of_two(uint8_t x);
+
 // PCIE & MMIO helper APIs
 uint32_t device_pci_read_32 (uint32_t offset, int fp);
 void device_pci_write_32 (uint32_t offset, uint32_t data, int fp);

--- a/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_key_prog_4.c
+++ b/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_key_prog_4.c
@@ -17,6 +17,26 @@
 #include "cxl_ide_test_common.h"
 #include "cxl_ide_test_internal.h"
 
+static uint8_t mStreamId[0x100] = {0};
+
+static int construct_test_stream_id()
+{
+  int stream_id_cnt = 0;
+
+  for(uint16_t stream_id = 1; stream_id <= 0xff; stream_id++) {
+    if(is_power_of_two(stream_id) || stream_id == 1 || stream_id == 0xff) {
+      mStreamId[stream_id_cnt++] = stream_id;
+    }
+  }
+
+  TEEIO_DEBUG((TEEIO_DEBUG_INFO, "construct test stream_id list. Total %d stream_id.\n", stream_id_cnt));
+  for(int i = 0; i < stream_id_cnt; i++) {
+    TEEIO_DEBUG((TEEIO_DEBUG_INFO, "  mStreamId[%d] = 0x%02x\n", i, mStreamId[i]));
+  }
+
+  return stream_id_cnt;
+}
+
 bool cxl_ide_test_key_prog_4_setup(void *test_context)
 {
   // Cxl.Query has been called in test_group.setup()
@@ -44,8 +64,10 @@ bool cxl_ide_test_key_prog_4_run(void *test_context)
   ide_common_test_port_context_t *lower_port = &group_context->common.lower_port;
   char case_info[MAX_LINE_LENGTH] = {0};
   int max_port_index = lower_port->cxl_data.query_resp.max_port_index;
+  int stream_id_cnt = construct_test_stream_id();
   for(int port_index = 0; port_index <= max_port_index; port_index++) {
-    for(int stream_id = 1; stream_id <= 0xff; stream_id++) {
+    for(int i = 0; i < stream_id_cnt; i++) {
+      uint8_t stream_id = mStreamId[i];
       sprintf(case_info, "  port_index = 0x%02x stream_id=0x%02x", port_index, stream_id);
       test_cxl_ide_key_prog(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context,
                             &group_context->spdm_doe.session_id, stream_id, CXL_IDE_KM_KEY_SUB_STREAM_CXL,

--- a/teeio-validator/library/helperlib/utils.c
+++ b/teeio-validator/library/helperlib/utils.c
@@ -580,3 +580,8 @@ void dump_key_iv_in_key_prog(const uint32_t *key, int key_dw_size, const uint32_
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "IV (big-endian):\n"));
   dump_hex_array((uint8_t *)iv_buf, iv_dw_size * sizeof(uint32_t));
 }
+
+bool is_power_of_two(uint8_t x)
+{
+  return (x != 0) && ((x & (x - 1)) == 0);
+}


### PR DESCRIPTION
Fix #275 
```
KeyProg Case 2.3
 construct test port_index list. Total 9 port_index.
   mPortIndex[0] = 0x01
   mPortIndex[1] = 0x02
   mPortIndex[2] = 0x04
   mPortIndex[3] = 0x08
   mPortIndex[4] = 0x10
   mPortIndex[5] = 0x20
   mPortIndex[6] = 0x40
   mPortIndex[7] = 0x80
   mPortIndex[8] = 0xff

KeyProg Case 2.4
 construct test stream_id list. Total 9 stream_id.
   mStreamId[0] = 0x01
   mStreamId[1] = 0x02
   mStreamId[2] = 0x04
   mStreamId[3] = 0x08
   mStreamId[4] = 0x10
   mStreamId[5] = 0x20
   mStreamId[6] = 0x40
   mStreamId[7] = 0x80
   mStreamId[8] = 0xff

KeyProg Case 2.5
 construct test sub_stream list. Total 7 sub_stream.
   mSubStream[0] = 0b0000
   mSubStream[1] = 0b0001
   mSubStream[2] = 0b0010
   mSubStream[3] = 0b0100
   mSubStream[4] = 0b0111
   mSubStream[5] = 0b1001
   mSubStream[6] = 0b1111
```