### PR TITLE
Redefine test case functions

### DIFF
--- a/teeio-validator/include/ide_test.h
+++ b/teeio-validator/include/ide_test.h
@@ -538,9 +538,9 @@ typedef struct {
 // test case setup function
 typedef bool(*ide_common_test_case_setup_func_t) (void *test_context);
 // test case teardown function
-typedef bool(*ide_common_test_case_teardown_func_t) (void *test_context);
+typedef void(*ide_common_test_case_teardown_func_t) (void *test_context);
 // test case run function
-typedef bool(*ide_common_test_case_run_func_t) (void *test_context);
+typedef void(*ide_common_test_case_run_func_t) (void *test_context);
 
 typedef struct _ide_run_test_case ide_run_test_case_t;
 struct _ide_run_test_case {

--- a/teeio-validator/library/cxl_ide_test_lib/include/cxl_ide_test_common.h
+++ b/teeio-validator/library/cxl_ide_test_lib/include/cxl_ide_test_common.h
@@ -12,75 +12,75 @@
 //
 // Full case
 bool cxl_ide_test_full_ide_stream_setup(void *test_context);
-bool cxl_ide_test_full_ide_stream_run(void *test_context);
-bool cxl_ide_test_full_ide_stream_teardown(void *test_context);
+void cxl_ide_test_full_ide_stream_run(void *test_context);
+void cxl_ide_test_full_ide_stream_teardown(void *test_context);
 
 // Key Refresh
 bool cxl_ide_test_keyrefresh_setup(void *test_context);
-bool cxl_ide_test_keyrefresh_run(void *test_context);
-bool cxl_ide_test_keyrefresh_teardown(void *test_context);
+void cxl_ide_test_keyrefresh_run(void *test_context);
+void cxl_ide_test_keyrefresh_teardown(void *test_context);
 
 // Query
 bool cxl_ide_test_query_1_setup(void *test_context);
-bool cxl_ide_test_query_1_run(void *test_context);
-bool cxl_ide_test_query_1_teardown(void *test_context);
+void cxl_ide_test_query_1_run(void *test_context);
+void cxl_ide_test_query_1_teardown(void *test_context);
 
 bool cxl_ide_test_query_2_setup(void *test_context);
-bool cxl_ide_test_query_2_run(void *test_context);
-bool cxl_ide_test_query_2_teardown(void *test_context);
+void cxl_ide_test_query_2_run(void *test_context);
+void cxl_ide_test_query_2_teardown(void *test_context);
 
 // KEY_PROG
 bool cxl_ide_test_key_prog_1_setup(void *test_context);
-bool cxl_ide_test_key_prog_1_run(void *test_context);
-bool cxl_ide_test_key_prog_1_teardown(void *test_context);
+void cxl_ide_test_key_prog_1_run(void *test_context);
+void cxl_ide_test_key_prog_1_teardown(void *test_context);
 
 bool cxl_ide_test_key_prog_2_setup(void *test_context);
-bool cxl_ide_test_key_prog_2_run(void *test_context);
-bool cxl_ide_test_key_prog_2_teardown(void *test_context);
+void cxl_ide_test_key_prog_2_run(void *test_context);
+void cxl_ide_test_key_prog_2_teardown(void *test_context);
 
 bool cxl_ide_test_key_prog_3_setup(void *test_context);
-bool cxl_ide_test_key_prog_3_run(void *test_context);
-bool cxl_ide_test_key_prog_3_teardown(void *test_context);
+void cxl_ide_test_key_prog_3_run(void *test_context);
+void cxl_ide_test_key_prog_3_teardown(void *test_context);
 
 bool cxl_ide_test_key_prog_4_setup(void *test_context);
-bool cxl_ide_test_key_prog_4_run(void *test_context);
-bool cxl_ide_test_key_prog_4_teardown(void *test_context);
+void cxl_ide_test_key_prog_4_run(void *test_context);
+void cxl_ide_test_key_prog_4_teardown(void *test_context);
 
 bool cxl_ide_test_key_prog_5_setup(void *test_context);
-bool cxl_ide_test_key_prog_5_run(void *test_context);
-bool cxl_ide_test_key_prog_5_teardown(void *test_context);
+void cxl_ide_test_key_prog_5_run(void *test_context);
+void cxl_ide_test_key_prog_5_teardown(void *test_context);
 
 bool cxl_ide_test_key_prog_6_setup(void *test_context);
-bool cxl_ide_test_key_prog_6_run(void *test_context);
-bool cxl_ide_test_key_prog_6_teardown(void *test_context);
+void cxl_ide_test_key_prog_6_run(void *test_context);
+void cxl_ide_test_key_prog_6_teardown(void *test_context);
 
 bool cxl_ide_test_key_prog_7_setup(void *test_context);
-bool cxl_ide_test_key_prog_7_run(void *test_context);
-bool cxl_ide_test_key_prog_7_teardown(void *test_context);
+void cxl_ide_test_key_prog_7_run(void *test_context);
+void cxl_ide_test_key_prog_7_teardown(void *test_context);
 
 bool cxl_ide_test_key_prog_8_setup(void *test_context);
-bool cxl_ide_test_key_prog_8_run(void *test_context);
-bool cxl_ide_test_key_prog_8_teardown(void *test_context);
+void cxl_ide_test_key_prog_8_run(void *test_context);
+void cxl_ide_test_key_prog_8_teardown(void *test_context);
 
 bool cxl_ide_test_key_prog_9_setup(void *test_context);
-bool cxl_ide_test_key_prog_9_run(void *test_context);
-bool cxl_ide_test_key_prog_9_teardown(void *test_context);
+void cxl_ide_test_key_prog_9_run(void *test_context);
+void cxl_ide_test_key_prog_9_teardown(void *test_context);
 
 // KSET_GO
 bool cxl_ide_test_kset_go_1_setup(void *test_context);
-bool cxl_ide_test_kset_go_1_run(void *test_context);
-bool cxl_ide_test_kset_go_1_teardown(void *test_context);
+void cxl_ide_test_kset_go_1_run(void *test_context);
+void cxl_ide_test_kset_go_1_teardown(void *test_context);
 
 // KSET_STOP
 bool cxl_ide_test_kset_stop_1_setup(void *test_context);
-bool cxl_ide_test_kset_stop_1_run(void *test_context);
-bool cxl_ide_test_kset_stop_1_teardown(void *test_context);
+void cxl_ide_test_kset_stop_1_run(void *test_context);
+void cxl_ide_test_kset_stop_1_teardown(void *test_context);
 
 // GET_KEY
 // KSET_GO
 bool cxl_ide_test_get_key_1_setup(void *test_context);
-bool cxl_ide_test_get_key_1_run(void *test_context);
-bool cxl_ide_test_get_key_1_teardown(void *test_context);
+void cxl_ide_test_get_key_1_run(void *test_context);
+void cxl_ide_test_get_key_1_teardown(void *test_context);
 
 //
 // CXL_IDE Test Config

--- a/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_full.c
+++ b/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_full.c
@@ -49,7 +49,7 @@ bool cxl_ide_test_full_ide_stream_setup(void *test_context)
                               false);
 }
 
-bool cxl_ide_test_full_ide_stream_run(void *test_context)
+void cxl_ide_test_full_ide_stream_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -87,10 +87,9 @@ bool cxl_ide_test_full_ide_stream_run(void *test_context)
   getchar();
 
   teeio_record_assertion_result(case_class, case_id, 1, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST, TEEIO_TEST_RESULT_PASS, "CXL-IDE Stream is setup.");
-  return true;
 }
 
-bool cxl_ide_test_full_ide_stream_teardown(void *test_context)
+void cxl_ide_test_full_ide_stream_teardown(void *test_context)
 {
   bool ret = false;
 
@@ -116,7 +115,7 @@ bool cxl_ide_test_full_ide_stream_teardown(void *test_context)
                               upper_port, lower_port);
     if(!ret) {
       TEEIO_DEBUG((TEEIO_DEBUG_ERROR, "cxl_stop_ide_stream failed.\n"));
-      return false;
+      return;
     }
   } else {
     TEEIO_DEBUG((TEEIO_DEBUG_INFO, "KSetStop is not supported.\n"));
@@ -125,6 +124,4 @@ bool cxl_ide_test_full_ide_stream_teardown(void *test_context)
   // clear LinkEncEnable on the RootPort side
   INTEL_KEYP_CXL_ROOT_COMPLEX_KCBAR *kcbar_ptr = (INTEL_KEYP_CXL_ROOT_COMPLEX_KCBAR *)upper_port->mapped_kcbar_addr;
   cxl_cfg_rp_linkenc_enable(kcbar_ptr, false);
-
-  return true;
 }

--- a/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_get_key_1.c
+++ b/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_get_key_1.c
@@ -121,7 +121,7 @@ bool cxl_ide_test_get_key_1_setup(void *test_context)
   return true;
 }
 
-bool cxl_ide_test_get_key_1_run(void *test_context)
+void cxl_ide_test_get_key_1_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -153,11 +153,8 @@ bool cxl_ide_test_get_key_1_run(void *test_context)
                             case_info, case_class, case_id);
     }
   }
-
-  return true;
 }
 
-bool cxl_ide_test_get_key_1_teardown(void *test_context)
+void cxl_ide_test_get_key_1_teardown(void *test_context)
 {
-  return true;
 }

--- a/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_key_prog_1.c
+++ b/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_key_prog_1.c
@@ -141,7 +141,7 @@ bool cxl_ide_test_key_prog_1_setup(void *test_context)
   return true;
 }
 
-bool cxl_ide_test_key_prog_1_run(void *test_context)
+void cxl_ide_test_key_prog_1_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -169,11 +169,8 @@ bool cxl_ide_test_key_prog_1_run(void *test_context)
                           i, false, case_info,
                           case_class, case_id, test_cxl_ide_key_prog_valid_params);
   }
-
-  return true;
 }
 
-bool cxl_ide_test_key_prog_1_teardown(void *test_context)
+void cxl_ide_test_key_prog_1_teardown(void *test_context)
 {
-  return true;
 }

--- a/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_key_prog_2.c
+++ b/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_key_prog_2.c
@@ -96,7 +96,7 @@ bool cxl_ide_test_key_prog_2_setup(void *test_context)
   return true;
 }
 
-bool cxl_ide_test_key_prog_2_run(void *test_context)
+void cxl_ide_test_key_prog_2_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -126,11 +126,8 @@ bool cxl_ide_test_key_prog_2_run(void *test_context)
                             case_class, case_id, test_cxl_ide_key_prog2);
     }
   }
-
-  return true;
 }
 
-bool cxl_ide_test_key_prog_2_teardown(void *test_context)
+void cxl_ide_test_key_prog_2_teardown(void *test_context)
 {
-  return true;
 }

--- a/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_key_prog_3.c
+++ b/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_key_prog_3.c
@@ -138,7 +138,7 @@ bool cxl_ide_test_key_prog_3_setup(void *test_context)
   return true;
 }
 
-bool cxl_ide_test_key_prog_3_run(void *test_context)
+void cxl_ide_test_key_prog_3_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -170,11 +170,8 @@ bool cxl_ide_test_key_prog_3_run(void *test_context)
                           port_index, false, case_info,
                           case_class, case_id, test_cxl_ide_key_prog_invalid_params);
   }
-
-  return true;
 }
 
-bool cxl_ide_test_key_prog_3_teardown(void *test_context)
+void cxl_ide_test_key_prog_3_teardown(void *test_context)
 {
-  return true;
 }

--- a/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_key_prog_4.c
+++ b/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_key_prog_4.c
@@ -43,7 +43,7 @@ bool cxl_ide_test_key_prog_4_setup(void *test_context)
   return true;
 }
 
-bool cxl_ide_test_key_prog_4_run(void *test_context)
+void cxl_ide_test_key_prog_4_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -75,11 +75,8 @@ bool cxl_ide_test_key_prog_4_run(void *test_context)
                             case_class, case_id, test_cxl_ide_key_prog_invalid_params);
       }
   }
-
-  return true;
 }
 
-bool cxl_ide_test_key_prog_4_teardown(void *test_context)
+void cxl_ide_test_key_prog_4_teardown(void *test_context)
 {
-  return true;
 }

--- a/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_key_prog_5.c
+++ b/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_key_prog_5.c
@@ -59,7 +59,7 @@ bool cxl_ide_test_key_prog_5_setup(void *test_context)
   return true;
 }
 
-bool cxl_ide_test_key_prog_5_run(void *test_context)
+void cxl_ide_test_key_prog_5_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -93,11 +93,8 @@ bool cxl_ide_test_key_prog_5_run(void *test_context)
                             case_class, case_id, test_cxl_ide_key_prog_invalid_params);
     }
   }
-
-  return true;
 }
 
-bool cxl_ide_test_key_prog_5_teardown(void *test_context)
+void cxl_ide_test_key_prog_5_teardown(void *test_context)
 {
-  return true;
 }

--- a/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_key_prog_6.c
+++ b/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_key_prog_6.c
@@ -114,7 +114,7 @@ bool cxl_ide_test_key_prog_6_setup(void *test_context)
   return true;
 }
 
-bool cxl_ide_test_key_prog_6_run(void *test_context)
+void cxl_ide_test_key_prog_6_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -138,11 +138,8 @@ bool cxl_ide_test_key_prog_6_run(void *test_context)
     test_cxl_ide_key_prog_6(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context,
                           &group_context->spdm_doe.session_id, i, case_class, case_id);
   }
-
-  return true;
 }
 
-bool cxl_ide_test_key_prog_6_teardown(void *test_context)
+void cxl_ide_test_key_prog_6_teardown(void *test_context)
 {
-  return true;
 }

--- a/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_key_prog_7.c
+++ b/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_key_prog_7.c
@@ -210,7 +210,7 @@ bool cxl_ide_test_key_prog_7_setup(void *test_context)
   return true;
 }
 
-bool cxl_ide_test_key_prog_7_run(void *test_context)
+void cxl_ide_test_key_prog_7_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -237,16 +237,12 @@ bool cxl_ide_test_key_prog_7_run(void *test_context)
                             case_class, case_id);
     }
   }
-
-  return true;
 }
 
-bool cxl_ide_test_key_prog_7_teardown(void *test_context)
+void cxl_ide_test_key_prog_7_teardown(void *test_context)
 {
   if(m_dev_caps) {
     free(m_dev_caps);
     m_dev_caps = NULL;
   }
-
-  return true;
 }

--- a/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_key_prog_8.c
+++ b/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_key_prog_8.c
@@ -154,7 +154,7 @@ bool cxl_ide_test_key_prog_8_setup(void *test_context)
   return true;
 }
 
-bool cxl_ide_test_key_prog_8_run(void *test_context)
+void cxl_ide_test_key_prog_8_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -181,16 +181,12 @@ bool cxl_ide_test_key_prog_8_run(void *test_context)
                             case_class, case_id);
     }
   }
-
-  return true;
 }
 
-bool cxl_ide_test_key_prog_8_teardown(void *test_context)
+void cxl_ide_test_key_prog_8_teardown(void *test_context)
 {
   if(m_dev_caps) {
     free(m_dev_caps);
     m_dev_caps = NULL;
   }
-
-  return true;
 }

--- a/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_key_prog_9.c
+++ b/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_key_prog_9.c
@@ -132,7 +132,7 @@ bool cxl_ide_test_key_prog_9_setup(void *test_context)
   return true;
 }
 
-bool cxl_ide_test_key_prog_9_run(void *test_context)
+void cxl_ide_test_key_prog_9_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -159,16 +159,12 @@ bool cxl_ide_test_key_prog_9_run(void *test_context)
                             case_class, case_id);
     }
   }
-
-  return true;
 }
 
-bool cxl_ide_test_key_prog_9_teardown(void *test_context)
+void cxl_ide_test_key_prog_9_teardown(void *test_context)
 {
   if(m_dev_caps) {
     free(m_dev_caps);
     m_dev_caps = NULL;
   }
-
-  return true;
 }

--- a/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_keyrefresh.c
+++ b/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_keyrefresh.c
@@ -50,7 +50,7 @@ bool cxl_ide_test_keyrefresh_setup(void *test_context)
                               false);
 }
 
-bool cxl_ide_test_keyrefresh_run(void *test_context)
+void cxl_ide_test_keyrefresh_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -111,11 +111,9 @@ bool cxl_ide_test_keyrefresh_run(void *test_context)
   teeio_record_assertion_result(case_class, case_id, 1, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
                                 res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED,
                                 res ? "CXL-IDE KeyRefresh succeeded." : "CXL-IDE KeyRefresh failed.");
-
-  return res;
 }
 
-bool cxl_ide_test_keyrefresh_teardown(void *test_context)
+void cxl_ide_test_keyrefresh_teardown(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -131,6 +129,4 @@ bool cxl_ide_test_keyrefresh_teardown(void *test_context)
   // clear LinkEncEnable on the RootPort side
   INTEL_KEYP_CXL_ROOT_COMPLEX_KCBAR *kcbar_ptr = (INTEL_KEYP_CXL_ROOT_COMPLEX_KCBAR *)upper_port->mapped_kcbar_addr;
   cxl_cfg_rp_linkenc_enable(kcbar_ptr, false);
-
-  return true;
 }

--- a/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_kset_go_1.c
+++ b/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_kset_go_1.c
@@ -244,7 +244,7 @@ bool cxl_ide_test_kset_go_1_setup(void *test_context)
   return true;
 }
 
-bool cxl_ide_test_kset_go_1_run(void *test_context)
+void cxl_ide_test_kset_go_1_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -274,11 +274,8 @@ bool cxl_ide_test_kset_go_1_run(void *test_context)
                             &group_context->spdm_doe.session_id, port_index, ide_mode, case_class, case_id);
     }
   }
-
-  return true;
 }
 
-bool cxl_ide_test_kset_go_1_teardown(void *test_context)
+void cxl_ide_test_kset_go_1_teardown(void *test_context)
 {
-  return true;
 }

--- a/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_kset_stop_1.c
+++ b/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_kset_stop_1.c
@@ -243,7 +243,7 @@ bool cxl_ide_test_kset_stop_1_setup(void *test_context)
   return true;
 }
 
-bool cxl_ide_test_kset_stop_1_run(void *test_context)
+void cxl_ide_test_kset_stop_1_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -281,11 +281,8 @@ bool cxl_ide_test_kset_stop_1_run(void *test_context)
                               case_class, case_id);
     }
   }
-
-  return true;
 }
 
-bool cxl_ide_test_kset_stop_1_teardown(void *test_context)
+void cxl_ide_test_kset_stop_1_teardown(void *test_context)
 {
-  return true;
 }

--- a/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_query_1.c
+++ b/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_query_1.c
@@ -92,7 +92,7 @@ bool cxl_ide_test_query_1_setup(void *test_context)
   return true;
 }
 
-bool cxl_ide_test_query_1_run(void *test_context)
+void cxl_ide_test_query_1_run(void *test_context)
 {
   uint8_t bus_num;
   uint8_t segment;
@@ -120,11 +120,8 @@ bool cxl_ide_test_query_1_run(void *test_context)
                       &group_context->spdm_doe.session_id,
                       0, dev_func_num, bus_num, segment,
                       case_class, case_id);
-
-  return true;
 }
 
-bool cxl_ide_test_query_1_teardown(void *test_context)
+void cxl_ide_test_query_1_teardown(void *test_context)
 {
-  return true;
 }

--- a/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_query_2.c
+++ b/teeio-validator/library/cxl_ide_test_lib/test_case/test_case_query_2.c
@@ -70,7 +70,7 @@ bool cxl_ide_test_query_2_setup(void *test_context)
   return true;
 }
 
-bool cxl_ide_test_query_2_run(void *test_context)
+void cxl_ide_test_query_2_run(void *test_context)
 {
   uint8_t bus_num;
   uint8_t segment;
@@ -101,11 +101,8 @@ bool cxl_ide_test_query_2_run(void *test_context)
                         i, dev_func_num, bus_num, segment,
                         case_class, case_id);
   }
-
-  return true;
 }
 
-bool cxl_ide_test_query_2_teardown(void *test_context)
+void cxl_ide_test_query_2_teardown(void *test_context)
 {
-  return true;
 }

--- a/teeio-validator/library/cxl_tsp_test_lib/include/cxl_tsp_test_common.h
+++ b/teeio-validator/library/cxl_tsp_test_lib/include/cxl_tsp_test_common.h
@@ -12,37 +12,37 @@
 //
 // GetVersion
 bool cxl_tsp_test_get_version_setup(void *test_context);
-bool cxl_tsp_test_get_version_run(void *test_context);
-bool cxl_tsp_test_get_version_teardown(void *test_context);
+void cxl_tsp_test_get_version_run(void *test_context);
+void cxl_tsp_test_get_version_teardown(void *test_context);
 
 // GetCaps
 bool cxl_tsp_test_get_caps_setup(void *test_context);
-bool cxl_tsp_test_get_caps_run(void *test_context);
-bool cxl_tsp_test_get_caps_teardown(void *test_context);
+void cxl_tsp_test_get_caps_run(void *test_context);
+void cxl_tsp_test_get_caps_teardown(void *test_context);
 
 // SetConfiguration
 bool cxl_tsp_test_set_configuration_setup(void *test_context);
-bool cxl_tsp_test_set_configuration_run(void *test_context);
-bool cxl_tsp_test_set_configuration_teardown(void *test_context);
+void cxl_tsp_test_set_configuration_run(void *test_context);
+void cxl_tsp_test_set_configuration_teardown(void *test_context);
 
 // GetConfiguration
 bool cxl_tsp_test_get_configuration_setup(void *test_context);
-bool cxl_tsp_test_get_configuration_run(void *test_context);
-bool cxl_tsp_test_get_configuration_teardown(void *test_context);
+void cxl_tsp_test_get_configuration_run(void *test_context);
+void cxl_tsp_test_get_configuration_teardown(void *test_context);
 
 // GetConfigurationReport
 bool cxl_tsp_test_get_configuration_report_setup(void *test_context);
-bool cxl_tsp_test_get_configuration_report_run(void *test_context);
-bool cxl_tsp_test_get_configuration_report_teardown(void *test_context);
+void cxl_tsp_test_get_configuration_report_run(void *test_context);
+void cxl_tsp_test_get_configuration_report_teardown(void *test_context);
 
 // LockConfiguration
 bool cxl_tsp_test_lock_configuration_1_setup(void *test_context);
-bool cxl_tsp_test_lock_configuration_1_run(void *test_context);
-bool cxl_tsp_test_lock_configuration_1_teardown(void *test_context);
+void cxl_tsp_test_lock_configuration_1_run(void *test_context);
+void cxl_tsp_test_lock_configuration_1_teardown(void *test_context);
 
 bool cxl_tsp_test_lock_configuration_2_setup(void *test_context);
-bool cxl_tsp_test_lock_configuration_2_run(void *test_context);
-bool cxl_tsp_test_lock_configuration_2_teardown(void *test_context);
+void cxl_tsp_test_lock_configuration_2_run(void *test_context);
+void cxl_tsp_test_lock_configuration_2_teardown(void *test_context);
 
 //
 // CXL_TSP Test Config

--- a/teeio-validator/library/cxl_tsp_test_lib/test_case/test_case_get_caps_1.c
+++ b/teeio-validator/library/cxl_tsp_test_lib/test_case/test_case_get_caps_1.c
@@ -306,7 +306,7 @@ bool cxl_tsp_test_get_caps_setup(void *test_context)
   return true;
 }
 
-bool cxl_tsp_test_get_caps_run(void *test_context)
+void cxl_tsp_test_get_caps_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -327,11 +327,8 @@ bool cxl_tsp_test_get_caps_run(void *test_context)
   libcxltsp_device_capabilities_t device_capabilities;
   memset(&device_capabilities, 0, sizeof(device_capabilities));
   test_cxl_tsp_get_capabilities(spdm_doe->doe_context, spdm_doe->spdm_context, &spdm_doe->session_id, &device_capabilities, case_class, case_id);
-
-  return true;
 }
 
-bool cxl_tsp_test_get_caps_teardown(void *test_context)
+void cxl_tsp_test_get_caps_teardown(void *test_context)
 {
-  return true;
 }

--- a/teeio-validator/library/cxl_tsp_test_lib/test_case/test_case_get_configuration_1.c
+++ b/teeio-validator/library/cxl_tsp_test_lib/test_case/test_case_get_configuration_1.c
@@ -247,7 +247,7 @@ bool cxl_tsp_test_get_configuration_setup(void *test_context)
   return true;
 }
 
-bool cxl_tsp_test_get_configuration_run(void *test_context)
+void cxl_tsp_test_get_configuration_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -270,11 +270,8 @@ bool cxl_tsp_test_get_configuration_run(void *test_context)
   test_cxl_tsp_get_configuration(spdm_doe->doe_context, spdm_doe->spdm_context,
                                 &spdm_doe->session_id, &current_device_configuration,
                                 case_class, case_id);
-
-  return true;
 }
 
-bool cxl_tsp_test_get_configuration_teardown(void *test_context)
+void cxl_tsp_test_get_configuration_teardown(void *test_context)
 {
-  return true;
 }

--- a/teeio-validator/library/cxl_tsp_test_lib/test_case/test_case_get_configuration_report_1.c
+++ b/teeio-validator/library/cxl_tsp_test_lib/test_case/test_case_get_configuration_report_1.c
@@ -157,7 +157,7 @@ bool cxl_tsp_test_get_configuration_report_setup(void *test_context)
   return true;
 }
 
-bool cxl_tsp_test_get_configuration_report_run(void *test_context)
+void cxl_tsp_test_get_configuration_report_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -184,11 +184,8 @@ bool cxl_tsp_test_get_configuration_report_run(void *test_context)
                                         configuration_report_buffer,
                                         &configuration_report_size,
                                         case_class, case_id);
-
-  return true;
 }
 
-bool cxl_tsp_test_get_configuration_report_teardown(void *test_context)
+void cxl_tsp_test_get_configuration_report_teardown(void *test_context)
 {
-  return true;
 }

--- a/teeio-validator/library/cxl_tsp_test_lib/test_case/test_case_get_version_1.c
+++ b/teeio-validator/library/cxl_tsp_test_lib/test_case/test_case_get_version_1.c
@@ -93,7 +93,7 @@ bool cxl_tsp_test_get_version_setup(void *test_context)
   return true;
 }
 
-bool cxl_tsp_test_get_version_run(void *test_context)
+void cxl_tsp_test_get_version_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -112,11 +112,8 @@ bool cxl_tsp_test_get_version_run(void *test_context)
   TEEIO_ASSERT(spdm_doe);
 
   cxl_tsp_test_get_version(spdm_doe->doe_context, spdm_doe->spdm_context, &spdm_doe->session_id, case_class, case_id);
-
-  return true;
 }
 
-bool cxl_tsp_test_get_version_teardown(void *test_context)
+void cxl_tsp_test_get_version_teardown(void *test_context)
 {
-  return true;
 }

--- a/teeio-validator/library/cxl_tsp_test_lib/test_case/test_case_lock_configuration_1.c
+++ b/teeio-validator/library/cxl_tsp_test_lib/test_case/test_case_lock_configuration_1.c
@@ -102,7 +102,7 @@ bool cxl_tsp_test_lock_configuration_1_setup(void *test_context)
   return true;
 }
 
-bool cxl_tsp_test_lock_configuration_1_run(void *test_context)
+void cxl_tsp_test_lock_configuration_1_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -125,16 +125,12 @@ bool cxl_tsp_test_lock_configuration_1_run(void *test_context)
     spdm_doe->spdm_context,
     &spdm_doe->session_id,
     case_class, case_id);
-
-  return true;
 }
 
-bool cxl_tsp_test_lock_configuration_1_teardown(void *test_context)
+void cxl_tsp_test_lock_configuration_1_teardown(void *test_context)
 {
   TEEIO_PRINT(("CXL TSP test LOCK_CONFIGURATION Case 6.1 is done.\n"));
   TEEIO_PRINT(("If there are some other CXL TSP test cases, the device shall be first reset.\n"));
   TEEIO_PRINT(("Press any key to continue.\n"));
   getchar();
-  
-  return true;
 }

--- a/teeio-validator/library/cxl_tsp_test_lib/test_case/test_case_lock_configuration_2.c
+++ b/teeio-validator/library/cxl_tsp_test_lib/test_case/test_case_lock_configuration_2.c
@@ -123,7 +123,7 @@ bool cxl_tsp_test_lock_configuration_2_setup(void *test_context)
   return true;
 }
 
-bool cxl_tsp_test_lock_configuration_2_run(void *test_context)
+void cxl_tsp_test_lock_configuration_2_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -146,16 +146,12 @@ bool cxl_tsp_test_lock_configuration_2_run(void *test_context)
     spdm_doe->spdm_context,
     &spdm_doe->session_id,
     case_class, case_id);
-
-  return true;
 }
 
-bool cxl_tsp_test_lock_configuration_2_teardown(void *test_context)
+void cxl_tsp_test_lock_configuration_2_teardown(void *test_context)
 {
   TEEIO_PRINT(("CXL TSP test LOCK_CONFIGURATION Case 6.2 is done.\n"));
   TEEIO_PRINT(("If there are some other CXL TSP test cases, the device shall be first reset.\n"));
   TEEIO_PRINT(("Press any key to continue.\n"));
   getchar();
-  
-  return true;
 }

--- a/teeio-validator/library/cxl_tsp_test_lib/test_case/test_case_set_configuration_1.c
+++ b/teeio-validator/library/cxl_tsp_test_lib/test_case/test_case_set_configuration_1.c
@@ -126,7 +126,7 @@ bool cxl_tsp_test_set_configuration_setup(void *test_context)
   return true;
 }
 
-bool cxl_tsp_test_set_configuration_run(void *test_context)
+void cxl_tsp_test_set_configuration_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -191,7 +191,7 @@ bool cxl_tsp_test_set_configuration_run(void *test_context)
                                   IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST, TEEIO_TEST_RESULT_FAILED,
                                   "device_capabilites.num_of_secondary_sessions is error - 0x%x", m_device_capabilities.number_of_secondary_sessions);
 
-      return true;
+      return;
     }
 
     for (int index = 0; index < CXL_TSP_2ND_SESSION_COUNT; index++) {
@@ -203,18 +203,15 @@ bool cxl_tsp_test_set_configuration_run(void *test_context)
           teeio_record_assertion_result(case_class, case_id, 0,
                                       IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST, TEEIO_TEST_RESULT_FAILED,
                                       "libspdm_get_random_number is error");
-          return true;
+          return;
         }
       }
     }
   }
   test_cxl_tsp_set_configuration(spdm_doe->doe_context, spdm_doe->spdm_context, &spdm_doe->session_id,
                                       &device_configuration, &device_2nd_session_info, case_class, case_id);
-
-  return true;
 }
 
-bool cxl_tsp_test_set_configuration_teardown(void *test_context)
+void cxl_tsp_test_set_configuration_teardown(void *test_context)
 {
-  return true;
 }

--- a/teeio-validator/library/pcie_ide_test_lib/include/pcie_ide_common.h
+++ b/teeio-validator/library/pcie_ide_test_lib/include/pcie_ide_common.h
@@ -13,102 +13,102 @@
 
 // Query Case 1.1
 bool pcie_ide_test_query_1_setup(void *test_context);
-bool pcie_ide_test_query_1_run(void *test_context);
-bool pcie_ide_test_query_1_teardown(void *test_context);
+void pcie_ide_test_query_1_run(void *test_context);
+void pcie_ide_test_query_1_teardown(void *test_context);
 
 // Query Case 1.2
 bool pcie_ide_test_query_2_setup(void *test_context);
-bool pcie_ide_test_query_2_run(void *test_context);
-bool pcie_ide_test_query_2_teardown(void *test_context);
+void pcie_ide_test_query_2_run(void *test_context);
+void pcie_ide_test_query_2_teardown(void *test_context);
 
 // KeyProg Case 2.1
 bool pcie_ide_test_keyprog_1_setup(void *test_context);
-bool pcie_ide_test_keyprog_1_run(void *test_context);
-bool pcie_ide_test_keyprog_1_teardown(void *test_context);
+void pcie_ide_test_keyprog_1_run(void *test_context);
+void pcie_ide_test_keyprog_1_teardown(void *test_context);
 
 // KeyProg Case 2.2
 bool pcie_ide_test_keyprog_2_setup(void *test_context);
-bool pcie_ide_test_keyprog_2_run(void *test_context);
-bool pcie_ide_test_keyprog_2_teardown(void *test_context);
+void pcie_ide_test_keyprog_2_run(void *test_context);
+void pcie_ide_test_keyprog_2_teardown(void *test_context);
 
 // KeyProg Case 2.3
 bool pcie_ide_test_keyprog_3_setup(void *test_context);
-bool pcie_ide_test_keyprog_3_run(void *test_context);
-bool pcie_ide_test_keyprog_3_teardown(void *test_context);
+void pcie_ide_test_keyprog_3_run(void *test_context);
+void pcie_ide_test_keyprog_3_teardown(void *test_context);
 
 // KeyProg Case 2.4
 bool pcie_ide_test_keyprog_4_setup(void *test_context);
-bool pcie_ide_test_keyprog_4_run(void *test_context);
-bool pcie_ide_test_keyprog_4_teardown(void *test_context);
+void pcie_ide_test_keyprog_4_run(void *test_context);
+void pcie_ide_test_keyprog_4_teardown(void *test_context);
 
 // KeyProg Case 2.5
 bool pcie_ide_test_keyprog_5_setup(void *test_context);
-bool pcie_ide_test_keyprog_5_run(void *test_context);
-bool pcie_ide_test_keyprog_5_teardown(void *test_context);
+void pcie_ide_test_keyprog_5_run(void *test_context);
+void pcie_ide_test_keyprog_5_teardown(void *test_context);
 
 // KeyProg Case 2.6
 bool pcie_ide_test_keyprog_6_setup(void *test_context);
-bool pcie_ide_test_keyprog_6_run(void *test_context);
-bool pcie_ide_test_keyprog_6_teardown(void *test_context);
+void pcie_ide_test_keyprog_6_run(void *test_context);
+void pcie_ide_test_keyprog_6_teardown(void *test_context);
 
 // KSetGo Case 3.1
 bool pcie_ide_test_ksetgo_1_setup(void *test_context);
-bool pcie_ide_test_ksetgo_1_run(void *test_context);
-bool pcie_ide_test_ksetgo_1_teardown(void *test_context);
+void pcie_ide_test_ksetgo_1_run(void *test_context);
+void pcie_ide_test_ksetgo_1_teardown(void *test_context);
 
 // KSetGo Case 3.2
 bool pcie_ide_test_ksetgo_2_setup(void *test_context);
-bool pcie_ide_test_ksetgo_2_run(void *test_context);
-bool pcie_ide_test_ksetgo_2_teardown(void *test_context);
+void pcie_ide_test_ksetgo_2_run(void *test_context);
+void pcie_ide_test_ksetgo_2_teardown(void *test_context);
 
 // KSetGo Case 3.3
 bool pcie_ide_test_ksetgo_3_setup(void *test_context);
-bool pcie_ide_test_ksetgo_3_run(void *test_context);
-bool pcie_ide_test_ksetgo_3_teardown(void *test_context);
+void pcie_ide_test_ksetgo_3_run(void *test_context);
+void pcie_ide_test_ksetgo_3_teardown(void *test_context);
 
 // KSetGo Case 3.4
 bool pcie_ide_test_ksetgo_4_setup(void *test_context);
-bool pcie_ide_test_ksetgo_4_run(void *test_context);
-bool pcie_ide_test_ksetgo_4_teardown(void *test_context);
+void pcie_ide_test_ksetgo_4_run(void *test_context);
+void pcie_ide_test_ksetgo_4_teardown(void *test_context);
 
 // KSetStop Case 4.1
 bool pcie_ide_test_ksetstop_1_setup(void *test_context);
-bool pcie_ide_test_ksetstop_1_run(void *test_context);
-bool pcie_ide_test_ksetstop_1_teardown(void *test_context);
+void pcie_ide_test_ksetstop_1_run(void *test_context);
+void pcie_ide_test_ksetstop_1_teardown(void *test_context);
 
 // KSetStop Case 4.2
 bool pcie_ide_test_ksetstop_2_setup(void *test_context);
-bool pcie_ide_test_ksetstop_2_run(void *test_context);
-bool pcie_ide_test_ksetstop_2_teardown(void *test_context);
+void pcie_ide_test_ksetstop_2_run(void *test_context);
+void pcie_ide_test_ksetstop_2_teardown(void *test_context);
 
 // KSetStop Case 4.3
 bool pcie_ide_test_ksetstop_3_setup(void *test_context);
-bool pcie_ide_test_ksetstop_3_run(void *test_context);
-bool pcie_ide_test_ksetstop_3_teardown(void *test_context);
+void pcie_ide_test_ksetstop_3_run(void *test_context);
+void pcie_ide_test_ksetstop_3_teardown(void *test_context);
 
 // KSetStop Case 4.4
 bool pcie_ide_test_ksetstop_4_setup(void *test_context);
-bool pcie_ide_test_ksetstop_4_run(void *test_context);
-bool pcie_ide_test_ksetstop_4_teardown(void *test_context);
+void pcie_ide_test_ksetstop_4_run(void *test_context);
+void pcie_ide_test_ksetstop_4_teardown(void *test_context);
 
 // SpdmSession
 bool pcie_ide_test_spdm_session_1_setup(void *test_context);
-bool pcie_ide_test_spdm_session_1_run(void *test_context);
-bool pcie_ide_test_spdm_session_1_teardown(void *test_context);
+void pcie_ide_test_spdm_session_1_run(void *test_context);
+void pcie_ide_test_spdm_session_1_teardown(void *test_context);
 
 bool pcie_ide_test_spdm_session_2_setup(void *test_context);
-bool pcie_ide_test_spdm_session_2_run(void *test_context);
-bool pcie_ide_test_spdm_session_2_teardown(void *test_context);
+void pcie_ide_test_spdm_session_2_run(void *test_context);
+void pcie_ide_test_spdm_session_2_teardown(void *test_context);
 
 // Full case
 bool pcie_ide_test_full_1_setup(void *test_context);
-bool pcie_ide_test_full_1_run(void *test_context);
-bool pcie_ide_test_full_1_teardown(void *test_context);
+void pcie_ide_test_full_1_run(void *test_context);
+void pcie_ide_test_full_1_teardown(void *test_context);
 
 // Full case - KeyRefresh
 bool pcie_ide_test_full_keyrefresh_setup(void *test_context);
-bool pcie_ide_test_full_keyrefresh_run(void *test_context);
-bool pcie_ide_test_full_keyrefresh_teardown(void *test_context);
+void pcie_ide_test_full_keyrefresh_run(void *test_context);
+void pcie_ide_test_full_keyrefresh_teardown(void *test_context);
 
 //
 // PCIE_IDE Test Config

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_full.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_full.c
@@ -44,7 +44,7 @@ bool pcie_ide_test_full_1_setup(void *test_context)
 
 }
 
-bool pcie_ide_test_full_1_run(void *test_context)
+void pcie_ide_test_full_1_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -90,7 +90,6 @@ bool pcie_ide_test_full_1_run(void *test_context)
   getchar();
 
   teeio_record_assertion_result(case_class, case_id, 1, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST, TEEIO_TEST_RESULT_PASS, "PCIE-IDE Stream is setup.");
-  return true;
 }
 
 static bool test_full_ide_km_key_set_stop(const void *pci_doe_context,
@@ -247,7 +246,7 @@ TestFullTeardownDone:
   return res;
 }
 
-bool pcie_ide_test_full_1_teardown(void *test_context)
+void pcie_ide_test_full_1_teardown(void *test_context)
 {
-  return pcie_ide_teardown_common(test_context, PCI_IDE_KM_KEY_SET_K0);
+  pcie_ide_teardown_common(test_context, PCI_IDE_KM_KEY_SET_K0);
 }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_full_keyrefresh.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_full_keyrefresh.c
@@ -49,7 +49,7 @@ bool pcie_ide_test_full_keyrefresh_setup(void *test_context)
                           0, group_context->common.top->type, upper_port, lower_port, false);
 }
 
-bool pcie_ide_test_full_keyrefresh_run(void *test_context)
+void pcie_ide_test_full_keyrefresh_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -139,11 +139,9 @@ bool pcie_ide_test_full_keyrefresh_run(void *test_context)
   teeio_record_assertion_result(case_class, case_id, 1, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
                                 res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED,
                                 res ? "PCIE-IDE KeyRefresh succeeded." : "PCIE-IDE KeyRefresh failed.");
-
-  return true;
 }
 
-bool pcie_ide_test_full_keyrefresh_teardown(void *test_context)
+void pcie_ide_test_full_keyrefresh_teardown(void *test_context)
 {
-  return pcie_ide_teardown_common(test_context, mKeySet);
+  pcie_ide_teardown_common(test_context, mKeySet);
 }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_1.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_1.c
@@ -151,7 +151,7 @@ bool pcie_ide_test_keyprog_1_setup(void *test_context)
   return test_keyprog_setup_common(test_context);
 }
 
-bool pcie_ide_test_keyprog_1_run(void *test_context)
+void pcie_ide_test_keyprog_1_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -312,11 +312,8 @@ bool pcie_ide_test_keyprog_1_run(void *test_context)
       group_context->rp_stream_index,
       PCIE_IDE_STREAM_TX,
       PCIE_IDE_STREAM_KS0);
-
-  return true;
 }
 
-bool pcie_ide_test_keyprog_1_teardown(void *test_context)
+void pcie_ide_test_keyprog_1_teardown(void *test_context)
 {
-  return true;
 }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_2.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_2.c
@@ -103,7 +103,7 @@ bool pcie_ide_test_keyprog_2_setup(void *test_context)
   return test_keyprog_setup_common(test_context);
 }
 
-bool pcie_ide_test_keyprog_2_run(void *test_context)
+void pcie_ide_test_keyprog_2_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -216,11 +216,8 @@ bool pcie_ide_test_keyprog_2_run(void *test_context)
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status, request_size, "K0|TX|CPL", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
-
-  return true;
 }
 
-bool pcie_ide_test_keyprog_2_teardown(void *test_context)
+void pcie_ide_test_keyprog_2_teardown(void *test_context)
 {
-  return true;
 }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_3.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_3.c
@@ -124,7 +124,7 @@ bool pcie_ide_test_keyprog_3_setup(void *test_context)
   return res;
 }
 
-bool pcie_ide_test_keyprog_3_run(void *test_context)
+void pcie_ide_test_keyprog_3_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -237,11 +237,8 @@ bool pcie_ide_test_keyprog_3_run(void *test_context)
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 port_index, &key_buffer, &kp_ack_status, "K0|TX|CPL", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
-
-  return true;
 }
 
-bool pcie_ide_test_keyprog_3_teardown(void *test_context)
+void pcie_ide_test_keyprog_3_teardown(void *test_context)
 {
-  return true;
 }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_4.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_4.c
@@ -105,7 +105,7 @@ bool pcie_ide_test_keyprog_4_setup(void *test_context)
   return test_keyprog_setup_common(test_context);
 }
 
-bool pcie_ide_test_keyprog_4_run(void *test_context)
+void pcie_ide_test_keyprog_4_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -211,11 +211,8 @@ bool pcie_ide_test_keyprog_4_run(void *test_context)
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status, "K0|TX|CPL", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
-
-  return true;
 }
 
-bool pcie_ide_test_keyprog_4_teardown(void *test_context)
+void pcie_ide_test_keyprog_4_teardown(void *test_context)
 {
-  return true;
 }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_5.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_5.c
@@ -106,7 +106,7 @@ bool pcie_ide_test_keyprog_5_setup(void *test_context)
   return test_keyprog_setup_common(test_context);
 }
 
-bool pcie_ide_test_keyprog_5_run(void *test_context)
+void pcie_ide_test_keyprog_5_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -218,11 +218,8 @@ bool pcie_ide_test_keyprog_5_run(void *test_context)
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status, "K0|TX|CPL", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
-
-  return true;
 }
 
-bool pcie_ide_test_keyprog_5_teardown(void *test_context)
+void pcie_ide_test_keyprog_5_teardown(void *test_context)
 {
-  return true;
 }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_6.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_6.c
@@ -105,7 +105,7 @@ bool pcie_ide_test_keyprog_6_setup(void *test_context)
   return test_keyprog_setup_common(test_context);
 }
 
-bool pcie_ide_test_keyprog_6_run(void *test_context)
+void pcie_ide_test_keyprog_6_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -217,11 +217,8 @@ bool pcie_ide_test_keyprog_6_run(void *test_context)
                                 k_sets[ks] | directions[direction] | substreams[substream],
                                 0, &key_buffer, &kp_ack_status, "K0|TX|CPL", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
-
-  return true;
 }
 
-bool pcie_ide_test_keyprog_6_teardown(void *test_context)
+void pcie_ide_test_keyprog_6_teardown(void *test_context)
 {
-  return true;
 }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_1.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_1.c
@@ -219,7 +219,7 @@ bool pcie_ide_test_ksetgo_1_setup(void *test_context)
     group_context->common.upper_port.ide_id, &group_context->k_set, 0, PCIE_IDE_STREAM_KS0);
 }
 
-bool pcie_ide_test_ksetgo_1_run(void *test_context)
+void pcie_ide_test_ksetgo_1_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -276,7 +276,7 @@ bool pcie_ide_test_ksetgo_1_run(void *test_context)
                               true, "K0|TX|CPL", case_class, case_id);
 
   if(teeio_test_case_result(case_class, case_id) != TEEIO_TEST_RESULT_PASS) {
-    return true;
+    return;
   }
 
   // enable dev ide
@@ -300,11 +300,9 @@ bool pcie_ide_test_ksetgo_1_run(void *test_context)
 
   // wait for 10 ms for device to get ide ready
   libspdm_sleep(10 * 1000);
-
-  return true;
 }
 
-bool pcie_ide_test_ksetgo_1_teardown(void *test_context)
+void pcie_ide_test_ksetgo_1_teardown(void *test_context)
 {
-  return pcie_ide_teardown_common(test_context, PCI_IDE_KM_KEY_SET_K0);
+  pcie_ide_teardown_common(test_context, PCI_IDE_KM_KEY_SET_K0);
 }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_2.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_2.c
@@ -42,7 +42,7 @@ bool pcie_ide_test_ksetgo_2_setup(void *test_context)
     group_context->common.upper_port.ide_id, &group_context->k_set, 0, PCIE_IDE_STREAM_KS1);
 }
 
-bool pcie_ide_test_ksetgo_2_run(void *test_context)
+void pcie_ide_test_ksetgo_2_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -99,7 +99,7 @@ bool pcie_ide_test_ksetgo_2_run(void *test_context)
                               true, "K1|TX|CPL", case_class, case_id);
 
   if(teeio_test_case_result(case_class, case_id) != TEEIO_TEST_RESULT_PASS) {
-    return true;
+    return;
   }
   // enable dev ide
   TEST_IDE_TYPE ide_type = TEST_IDE_TYPE_SEL_IDE;
@@ -122,11 +122,9 @@ bool pcie_ide_test_ksetgo_2_run(void *test_context)
 
   // wait for 10 ms for device to get ide ready
   libspdm_sleep(10 * 1000);
-
-  return true;
 }
 
-bool pcie_ide_test_ksetgo_2_teardown(void *test_context)
+void pcie_ide_test_ksetgo_2_teardown(void *test_context)
 {
-  return pcie_ide_teardown_common(test_context, PCI_IDE_KM_KEY_SET_K1);
+  pcie_ide_teardown_common(test_context, PCI_IDE_KM_KEY_SET_K1);
 }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_3.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_3.c
@@ -186,7 +186,7 @@ bool test_ksetgo_3_run_phase2(void* doe_context, void* spdm_context, uint32_t* s
   return true;
 }
 
-bool pcie_ide_test_ksetgo_3_run(void *test_context)
+void pcie_ide_test_ksetgo_3_run(void *test_context)
 {
   bool res = false;
 
@@ -237,10 +237,10 @@ bool pcie_ide_test_ksetgo_3_run(void *test_context)
                                 case_class, case_id);
 
 Done:
-  return true;
+  return;
 }
 
-bool pcie_ide_test_ksetgo_3_teardown(void *test_context)
+void pcie_ide_test_ksetgo_3_teardown(void *test_context)
 {
-  return pcie_ide_teardown_common(test_context, PCI_IDE_KM_KEY_SET_K1);
+  pcie_ide_teardown_common(test_context, PCI_IDE_KM_KEY_SET_K1);
 }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_4.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_4.c
@@ -184,7 +184,7 @@ bool test_ksetgo_4_run_phase2(void* doe_context, void* spdm_context, uint32_t* s
   return true;
 }
 
-bool pcie_ide_test_ksetgo_4_run(void *test_context)
+void pcie_ide_test_ksetgo_4_run(void *test_context)
 {
   bool res = false;
 
@@ -236,10 +236,10 @@ bool pcie_ide_test_ksetgo_4_run(void *test_context)
                                 case_class, case_id);
 
 Done:
-  return true;
+  return;
 }
 
-bool pcie_ide_test_ksetgo_4_teardown(void *test_context)
+void pcie_ide_test_ksetgo_4_teardown(void *test_context)
 {
-  return pcie_ide_teardown_common(test_context, PCI_IDE_KM_KEY_SET_K0);
+  pcie_ide_teardown_common(test_context, PCI_IDE_KM_KEY_SET_K0);
 }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_1.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_1.c
@@ -112,7 +112,7 @@ bool pcie_ide_test_ksetstop_1_setup(void *test_context)
 
 }
 
-bool pcie_ide_test_ksetstop_1_run(void *test_context)
+void pcie_ide_test_ksetstop_1_run(void *test_context)
 {
   // first diable dev_ide and host_ide
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
@@ -190,11 +190,8 @@ bool pcie_ide_test_ksetstop_1_run(void *test_context)
   test_pci_ide_km_key_set_stop(doe_context, spdm_context, &session_id, stream_id,
                              ks | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_CPL, port_index,
                              "K0|TX|CPL", case_class, case_id);
-
-  return true;
 }
 
-bool pcie_ide_test_ksetstop_1_teardown(void *test_context)
+void pcie_ide_test_ksetstop_1_teardown(void *test_context)
 {
-  return true;
 }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_2.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_2.c
@@ -43,7 +43,7 @@ bool pcie_ide_test_ksetstop_2_setup(void *test_context)
 
 }
 
-bool pcie_ide_test_ksetstop_2_run(void *test_context)
+void pcie_ide_test_ksetstop_2_run(void *test_context)
 {
   // first diable dev_ide and host_ide
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
@@ -120,10 +120,8 @@ bool pcie_ide_test_ksetstop_2_run(void *test_context)
                              PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_CPL, port_index,
                              "K1|TX|CPL", case_class, case_id);
 
-  return true;
 }
 
-bool pcie_ide_test_ksetstop_2_teardown(void *test_context)
+void pcie_ide_test_ksetstop_2_teardown(void *test_context)
 {
-  return true;
 }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_3.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_3.c
@@ -54,7 +54,7 @@ bool pcie_ide_test_ksetstop_3_setup(void *test_context)
   return res;
 }
 
-bool pcie_ide_test_ksetstop_3_run(void *test_context)
+void pcie_ide_test_ksetstop_3_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -128,11 +128,8 @@ bool pcie_ide_test_ksetstop_3_run(void *test_context)
   test_pci_ide_km_key_set_stop(doe_context, spdm_context, &session_id, stream_id,
                              PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_CPL, port_index,
                              "K1|TX|CPL", case_class, case_id);
-
-  return true;
 }
 
-bool pcie_ide_test_ksetstop_3_teardown(void *test_context)
+void pcie_ide_test_ksetstop_3_teardown(void *test_context)
 {
-  return true;
 }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_4.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_4.c
@@ -56,7 +56,7 @@ bool pcie_ide_test_ksetstop_4_setup(void *test_context)
   return res;
 }
 
-bool pcie_ide_test_ksetstop_4_run(void *test_context)
+void pcie_ide_test_ksetstop_4_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -131,11 +131,8 @@ bool pcie_ide_test_ksetstop_4_run(void *test_context)
   test_pci_ide_km_key_set_stop(doe_context, spdm_context, &session_id, stream_id,
                              PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_CPL, port_index,
                              "K0|TX|CPL", case_class, case_id);
-
-  return true;
 }
 
-bool pcie_ide_test_ksetstop_4_teardown(void *test_context)
+void pcie_ide_test_ksetstop_4_teardown(void *test_context)
 {
-  return true;
 }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_query_1.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_query_1.c
@@ -106,7 +106,7 @@ bool pcie_ide_test_query_1_setup(void *test_context)
   return true;
 }
 
-bool pcie_ide_test_query_1_run(void *test_context)
+void pcie_ide_test_query_1_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -137,11 +137,8 @@ bool pcie_ide_test_query_1_run(void *test_context)
                       port_index, &dev_func, &bus, &segment,
                       &max_port_index, ide_reg_block, &ide_reg_block_count,
                       case_class, case_id);
-
-  return true;
 }
 
-bool pcie_ide_test_query_1_teardown(void *test_context)
+void pcie_ide_test_query_1_teardown(void *test_context)
 {
-  return true;
 }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_query_2.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_query_2.c
@@ -70,7 +70,7 @@ bool pcie_ide_test_query_2_setup(void *test_context)
   return true;
 }
 
-bool pcie_ide_test_query_2_run(void *test_context)
+void pcie_ide_test_query_2_run(void *test_context)
 {
   ide_common_test_case_context_t *case_context = (ide_common_test_case_context_t *)test_context;
   TEEIO_ASSERT(case_context);
@@ -102,11 +102,9 @@ bool pcie_ide_test_query_2_run(void *test_context)
                       &max_port_index, ide_reg_block, &ide_reg_block_count,
                       case_class, case_id);
 
-  return true;
 }
 
-bool pcie_ide_test_query_2_teardown(void *test_context)
+void pcie_ide_test_query_2_teardown(void *test_context)
 {
   mMaxPortIndex = 0;
-  return true;
 }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_spdm_session_1.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_spdm_session_1.c
@@ -16,14 +16,12 @@ bool pcie_ide_test_spdm_session_1_setup(void *test_context)
   return false;
 }
 
-bool pcie_ide_test_spdm_session_1_run(void *test_context)
+void pcie_ide_test_spdm_session_1_run(void *test_context)
 {
   NOT_IMPLEMENTED(__func__);
-  return false;
 }
 
-bool pcie_ide_test_spdm_session_1_teardown(void *test_context)
+void pcie_ide_test_spdm_session_1_teardown(void *test_context)
 {
   NOT_IMPLEMENTED(__func__);
-  return false;
 }

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_spdm_session_2.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_spdm_session_2.c
@@ -16,14 +16,12 @@ bool pcie_ide_test_spdm_session_2_setup(void *test_context)
   return false;
 }
 
-bool pcie_ide_test_spdm_session_2_run(void *test_context)
+void pcie_ide_test_spdm_session_2_run(void *test_context)
 {
   NOT_IMPLEMENTED(__func__);
-  return false;
 }
 
-bool pcie_ide_test_spdm_session_2_teardown(void *test_context)
+void pcie_ide_test_spdm_session_2_teardown(void *test_context)
 {
   NOT_IMPLEMENTED(__func__);
-  return false;
 }

--- a/teeio-validator/library/tdisp_test_lib/include/tdisp_common.h
+++ b/teeio-validator/library/tdisp_test_lib/include/tdisp_common.h
@@ -15,113 +15,113 @@
 
 // Query Case 1.1
 bool tdisp_test_query_1_setup (void *test_context);
-bool tdisp_test_query_1_run (void *test_context);
-bool tdisp_test_query_1_teardown (void *test_context);
+void tdisp_test_query_1_run (void *test_context);
+void tdisp_test_query_1_teardown (void *test_context);
 
 // Query Case 1.2
 bool tdisp_test_query_2_setup (void *test_context);
-bool tdisp_test_query_2_run (void *test_context);
-bool tdisp_test_query_2_teardown (void *test_context);
+void tdisp_test_query_2_run (void *test_context);
+void tdisp_test_query_2_teardown (void *test_context);
 
 // LockInterface Case 2.1
 bool tdisp_test_lock_interface_1_setup (void *test_context);
-bool tdisp_test_lock_interface_1_run (void *test_context);
-bool tdisp_test_lock_interface_1_teardown (void *test_context);
+void tdisp_test_lock_interface_1_run (void *test_context);
+void tdisp_test_lock_interface_1_teardown (void *test_context);
 
 // LockInterface Case 2.2
 bool tdisp_test_lock_interface_2_setup (void *test_context);
-bool tdisp_test_lock_interface_2_run (void *test_context);
-bool tdisp_test_lock_interface_2_teardown (void *test_context);
+void tdisp_test_lock_interface_2_run (void *test_context);
+void tdisp_test_lock_interface_2_teardown (void *test_context);
 
 // LockInterface Case 2.3
 bool tdisp_test_lock_interface_3_setup (void *test_context);
-bool tdisp_test_lock_interface_3_run (void *test_context);
-bool tdisp_test_lock_interface_3_teardown (void *test_context);
+void tdisp_test_lock_interface_3_run (void *test_context);
+void tdisp_test_lock_interface_3_teardown (void *test_context);
 
 // LockInterface Case 2.4
 bool tdisp_test_lock_interface_4_setup (void *test_context);
-bool tdisp_test_lock_interface_4_run (void *test_context);
-bool tdisp_test_lock_interface_4_teardown (void *test_context);
+void tdisp_test_lock_interface_4_run (void *test_context);
+void tdisp_test_lock_interface_4_teardown (void *test_context);
 
 // DInterfaceReport Case 3.1
 bool tdisp_test_interface_report_1_setup (void *test_context);
-bool tdisp_test_interface_report_1_run (void *test_context);
-bool tdisp_test_interface_report_1_teardown (void *test_context);
+void tdisp_test_interface_report_1_run (void *test_context);
+void tdisp_test_interface_report_1_teardown (void *test_context);
 
 // DInterfaceReport Case 3.2
 bool tdisp_test_interface_report_2_setup (void *test_context);
-bool tdisp_test_interface_report_2_run (void *test_context);
-bool tdisp_test_interface_report_2_teardown (void *test_context);
+void tdisp_test_interface_report_2_run (void *test_context);
+void tdisp_test_interface_report_2_teardown (void *test_context);
 
 // DInterfaceReport Case 3.3
 bool tdisp_test_interface_report_3_setup (void *test_context);
-bool tdisp_test_interface_report_3_run (void *test_context);
-bool tdisp_test_interface_report_3_teardown (void *test_context);
+void tdisp_test_interface_report_3_run (void *test_context);
+void tdisp_test_interface_report_3_teardown (void *test_context);
 
 // DInterfaceReport Case 3.4
 bool tdisp_test_interface_report_4_setup (void *test_context);
-bool tdisp_test_interface_report_4_run (void *test_context);
-bool tdisp_test_interface_report_4_teardown (void *test_context);
+void tdisp_test_interface_report_4_run (void *test_context);
+void tdisp_test_interface_report_4_teardown (void *test_context);
 
 // DInterfaceReport Case 3.5
 bool tdisp_test_interface_report_5_setup (void *test_context);
-bool tdisp_test_interface_report_5_run (void *test_context);
-bool tdisp_test_interface_report_5_teardown (void *test_context);
+void tdisp_test_interface_report_5_run (void *test_context);
+void tdisp_test_interface_report_5_teardown (void *test_context);
 
 // DInterfaceState Case 4.1
 bool tdisp_test_interface_state_1_setup (void *test_context);
-bool tdisp_test_interface_state_1_run (void *test_context);
-bool tdisp_test_interface_state_1_teardown (void *test_context);
+void tdisp_test_interface_state_1_run (void *test_context);
+void tdisp_test_interface_state_1_teardown (void *test_context);
 
 // DInterfaceState Case 4.2
 bool tdisp_test_interface_state_2_setup (void *test_context);
-bool tdisp_test_interface_state_2_run (void *test_context);
-bool tdisp_test_interface_state_2_teardown (void *test_context);
+void tdisp_test_interface_state_2_run (void *test_context);
+void tdisp_test_interface_state_2_teardown (void *test_context);
 
 // DInterfaceState Case 4.3
 bool tdisp_test_interface_state_3_setup (void *test_context);
-bool tdisp_test_interface_state_3_run (void *test_context);
-bool tdisp_test_interface_state_3_teardown (void *test_context);
+void tdisp_test_interface_state_3_run (void *test_context);
+void tdisp_test_interface_state_3_teardown (void *test_context);
 
 // DInterfaceState Case 4.4
 bool tdisp_test_interface_state_4_setup (void *test_context);
-bool tdisp_test_interface_state_4_run (void *test_context);
-bool tdisp_test_interface_state_4_teardown (void *test_context);
+void tdisp_test_interface_state_4_run (void *test_context);
+void tdisp_test_interface_state_4_teardown (void *test_context);
 
 // StartInterface Case 5.1
 bool tdisp_test_start_interface_1_setup (void *test_context);
-bool tdisp_test_start_interface_1_run (void *test_context);
-bool tdisp_test_start_interface_1_teardown (void *test_context);
+void tdisp_test_start_interface_1_run (void *test_context);
+void tdisp_test_start_interface_1_teardown (void *test_context);
 
 // StartInterface Case 5.2
 bool tdisp_test_start_interface_2_setup (void *test_context);
-bool tdisp_test_start_interface_2_run (void *test_context);
-bool tdisp_test_start_interface_2_teardown (void *test_context);
+void tdisp_test_start_interface_2_run (void *test_context);
+void tdisp_test_start_interface_2_teardown (void *test_context);
 
 // StartInterface Case 5.3
 bool tdisp_test_start_interface_3_setup (void *test_context);
-bool tdisp_test_start_interface_3_run (void *test_context);
-bool tdisp_test_start_interface_3_teardown (void *test_context);
+void tdisp_test_start_interface_3_run (void *test_context);
+void tdisp_test_start_interface_3_teardown (void *test_context);
 
 // StartInterface Case 5.4
 bool tdisp_test_start_interface_4_setup (void *test_context);
-bool tdisp_test_start_interface_4_run (void *test_context);
-bool tdisp_test_start_interface_4_teardown (void *test_context);
+void tdisp_test_start_interface_4_run (void *test_context);
+void tdisp_test_start_interface_4_teardown (void *test_context);
 
 // StopInterface Case 6.1
 bool tdisp_test_stop_interface_1_setup (void *test_context);
-bool tdisp_test_stop_interface_1_run (void *test_context);
-bool tdisp_test_stop_interface_1_teardown (void *test_context);
+void tdisp_test_stop_interface_1_run (void *test_context);
+void tdisp_test_stop_interface_1_teardown (void *test_context);
 
 // StopInterface Case 6.2
 bool tdisp_test_stop_interface_2_setup (void *test_context);
-bool tdisp_test_stop_interface_2_run (void *test_context);
-bool tdisp_test_stop_interface_2_teardown (void *test_context);
+void tdisp_test_stop_interface_2_run (void *test_context);
+void tdisp_test_stop_interface_2_teardown (void *test_context);
 
 // StopInterface Case 6.3
 bool tdisp_test_stop_interface_3_setup (void *test_context);
-bool tdisp_test_stop_interface_3_run (void *test_context);
-bool tdisp_test_stop_interface_3_teardown (void *test_context);
+void tdisp_test_stop_interface_3_run (void *test_context);
+void tdisp_test_stop_interface_3_teardown (void *test_context);
 
 //
 // TDISP Test Config

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_report_1.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_report_1.c
@@ -88,7 +88,7 @@ bool tdisp_test_interface_report_1_setup (void *test_context)
 	return setup_success = true;
 }
 
-bool tdisp_test_interface_report_1_run (void *test_context)
+void tdisp_test_interface_report_1_run (void *test_context)
 {
 	assert_context (test_context);
 
@@ -106,7 +106,7 @@ bool tdisp_test_interface_report_1_run (void *test_context)
 
 	if (!tdisp_test_get_interface_report (test_context, g_tdisp_interface_id.function_id,
 		interface_report_buffer, &buffer_size)) {
-		return false;
+		return;
 	}
 
 	pci_tdisp_device_interface_state_response_t get_state_response;
@@ -117,7 +117,7 @@ bool tdisp_test_interface_report_1_run (void *test_context)
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_interface_report_1_run get_state failed.\n"));
 
-		return false;
+		return;
 	}
 
 	bool res = (get_state_response.tdi_state == PCI_TDISP_INTERFACE_STATE_CONFIG_LOCKED);
@@ -125,19 +125,17 @@ bool tdisp_test_interface_report_1_run (void *test_context)
 
 	teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[0]);
-
-	return true;
 }
 
-bool tdisp_test_interface_report_1_teardown (void *test_context)
+void tdisp_test_interface_report_1_teardown (void *test_context)
 {
 	if (setup_success == false) {
-		return true;
+		return;
 	}
 
 	pci_tdisp_stop_interface_response_t response;
 	size_t response_size = sizeof (response);
 
-	return tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
+	tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
 		&response_size);
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_report_2.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_report_2.c
@@ -100,7 +100,7 @@ bool tdisp_test_interface_report_2_setup (void *test_context)
 	return setup_success = true;
 }
 
-bool tdisp_test_interface_report_2_run (void *test_context)
+void tdisp_test_interface_report_2_run (void *test_context)
 {
 	assert_context (test_context);
 
@@ -118,7 +118,7 @@ bool tdisp_test_interface_report_2_run (void *test_context)
 
 	if (!tdisp_test_get_interface_report (test_context, g_tdisp_interface_id.function_id,
 		interface_report_buffer, &buffer_size)) {
-		return false;
+		return;
 	}
 
 	pci_tdisp_device_interface_state_response_t get_state_response;
@@ -129,7 +129,7 @@ bool tdisp_test_interface_report_2_run (void *test_context)
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_interface_report_2_run get_state failed.\n"));
 
-		return false;
+		return;
 	}
 
 	bool res = (get_state_response.tdi_state == PCI_TDISP_INTERFACE_STATE_RUN);
@@ -138,18 +138,18 @@ bool tdisp_test_interface_report_2_run (void *test_context)
 	teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[0]);
 
-	return true;
+	return;
 }
 
-bool tdisp_test_interface_report_2_teardown (void *test_context)
+void tdisp_test_interface_report_2_teardown (void *test_context)
 {
 	if (setup_success == false) {
-		return true;
+		return;
 	}
 
 	pci_tdisp_stop_interface_response_t response;
 	size_t response_size = sizeof (response);
 
-	return tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
+	tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
 		&response_size);
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_report_3.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_report_3.c
@@ -99,7 +99,7 @@ bool tdisp_test_interface_report_3_setup (void *test_context)
 	return setup_success = true;
 }
 
-bool tdisp_test_interface_report_3_run (void *test_context)
+void tdisp_test_interface_report_3_run (void *test_context)
 {
 	assert_context (test_context);
 
@@ -171,7 +171,7 @@ bool tdisp_test_interface_report_3_run (void *test_context)
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_lock_interface_3_run get_state failed.\n"));
 
-		return false;
+		return;
 	}
 
 	res = (get_state_response.tdi_state == PCI_TDISP_INTERFACE_STATE_CONFIG_LOCKED);
@@ -179,18 +179,18 @@ bool tdisp_test_interface_report_3_run (void *test_context)
 	teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[6]);
 
-	return true;
+	return;
 }
 
-bool tdisp_test_interface_report_3_teardown (void *test_context)
+void tdisp_test_interface_report_3_teardown (void *test_context)
 {
 	if (setup_success == false) {
-		return true;
+		return;
 	}
 
 	pci_tdisp_stop_interface_response_t response;
 	size_t response_size = sizeof (response);
 
-	return tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
+	tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
 		&response_size);
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_report_4.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_report_4.c
@@ -81,7 +81,7 @@ bool tdisp_test_interface_report_4_setup (void *test_context)
 	return setup_success = true;
 }
 
-bool tdisp_test_interface_report_4_run (void *test_context)
+void tdisp_test_interface_report_4_run (void *test_context)
 {
 	assert_context (test_context);
 
@@ -153,7 +153,7 @@ bool tdisp_test_interface_report_4_run (void *test_context)
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_lock_interface_3_run get_state failed.\n"));
 
-		return false;
+		return;
 	}
 
 	res = (get_state_response.tdi_state == PCI_TDISP_INTERFACE_STATE_CONFIG_UNLOCKED);
@@ -161,18 +161,18 @@ bool tdisp_test_interface_report_4_run (void *test_context)
 	teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[6]);
 
-	return true;
+	return;
 }
 
-bool tdisp_test_interface_report_4_teardown (void *test_context)
+void tdisp_test_interface_report_4_teardown (void *test_context)
 {
 	if (setup_success == false) {
-		return true;
+		return;
 	}
 
 	pci_tdisp_stop_interface_response_t response;
 	size_t response_size = sizeof (response);
 
-	return tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
+	tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
 		&response_size);
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_report_5.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_report_5.c
@@ -90,7 +90,7 @@ bool tdisp_test_interface_report_5_setup (void *test_context)
 	return setup_success = true;
 }
 
-bool tdisp_test_interface_report_5_run (void *test_context)
+void tdisp_test_interface_report_5_run (void *test_context)
 {
 	assert_context (test_context);
 
@@ -108,7 +108,7 @@ bool tdisp_test_interface_report_5_run (void *test_context)
 
 	if (!tdisp_test_get_interface_report (test_context, g_tdisp_interface_id.function_id,
 		interface_report_buffer, &buffer_size)) {
-		return false;
+		return;
 	}
 
 	READ_DATA16 data16 = {.byte0 = interface_report_buffer[0], .byte1 = interface_report_buffer[1]};
@@ -159,18 +159,18 @@ bool tdisp_test_interface_report_5_run (void *test_context)
 			IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST, assertion_result, mAssertion[2]);
 	}
 
-	return true;
+	return;
 }
 
-bool tdisp_test_interface_report_5_teardown (void *test_context)
+void tdisp_test_interface_report_5_teardown (void *test_context)
 {
 	if (setup_success == false) {
-		return true;
+		return;
 	}
 
 	pci_tdisp_stop_interface_response_t response;
 	size_t response_size = sizeof (response);
 
-	return tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
+	tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
 		&response_size);
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_state_1.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_state_1.c
@@ -50,7 +50,7 @@ bool tdisp_test_interface_state_1_setup (void *test_context)
 	return setup_success = true;
 }
 
-bool tdisp_test_interface_state_1_run (void *test_context)
+void tdisp_test_interface_state_1_run (void *test_context)
 {
 	assert_context (test_context);
 
@@ -100,18 +100,18 @@ bool tdisp_test_interface_state_1_run (void *test_context)
 	teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[5]);
 
-	return true;
+	return;
 }
 
-bool tdisp_test_interface_state_1_teardown (void *test_context)
+void tdisp_test_interface_state_1_teardown (void *test_context)
 {
 	if (setup_success == false) {
-		return true;
+		return;
 	}
 
 	pci_tdisp_stop_interface_response_t response;
 	size_t response_size = sizeof (response);
 
-	return tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
+	tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
 		&response_size);
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_state_2.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_state_2.c
@@ -70,7 +70,7 @@ bool tdisp_test_interface_state_2_setup (void *test_context)
 	return setup_success = true;
 }
 
-bool tdisp_test_interface_state_2_run (void *test_context)
+void tdisp_test_interface_state_2_run (void *test_context)
 {
 	assert_context (test_context);
 
@@ -120,18 +120,18 @@ bool tdisp_test_interface_state_2_run (void *test_context)
 	teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[5]);
 
-	return true;
+	return;
 }
 
-bool tdisp_test_interface_state_2_teardown (void *test_context)
+void tdisp_test_interface_state_2_teardown (void *test_context)
 {
 	if (setup_success == false) {
-		return true;
+		return;
 	}
 
 	pci_tdisp_stop_interface_response_t response;
 	size_t response_size = sizeof (response);
 
-	return tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
+	tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
 		&response_size);
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_state_3.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_state_3.c
@@ -82,7 +82,7 @@ bool tdisp_test_interface_state_3_setup (void *test_context)
 	return setup_success = true;
 }
 
-bool tdisp_test_interface_state_3_run (void *test_context)
+void tdisp_test_interface_state_3_run (void *test_context)
 {
 	assert_context (test_context);
 
@@ -132,18 +132,18 @@ bool tdisp_test_interface_state_3_run (void *test_context)
 	teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[5]);
 
-	return true;
+	return;
 }
 
-bool tdisp_test_interface_state_3_teardown (void *test_context)
+void tdisp_test_interface_state_3_teardown (void *test_context)
 {
 	if (setup_success == false) {
-		return true;
+		return;
 	}
 
 	pci_tdisp_stop_interface_response_t response;
 	size_t response_size = sizeof (response);
 
-	return tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
+	tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
 		&response_size);
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_state_4.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_state_4.c
@@ -94,7 +94,7 @@ bool tdisp_test_interface_state_4_setup (void *test_context)
 	return setup_success = true;
 }
 
-bool tdisp_test_interface_state_4_run (void *test_context)
+void tdisp_test_interface_state_4_run (void *test_context)
 {
 	assert_context (test_context);
 
@@ -144,18 +144,18 @@ bool tdisp_test_interface_state_4_run (void *test_context)
 	teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[5]);
 
-	return true;
+	return;
 }
 
-bool tdisp_test_interface_state_4_teardown (void *test_context)
+void tdisp_test_interface_state_4_teardown (void *test_context)
 {
 	if (setup_success == false) {
-		return true;
+		return;
 	}
 
 	pci_tdisp_stop_interface_response_t response;
 	size_t response_size = sizeof (response);
 
-	return tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
+	tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
 		&response_size);
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_lock_interface_1.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_lock_interface_1.c
@@ -79,7 +79,7 @@ bool tdisp_test_lock_interface_1_setup (void *test_context)
 	return setup_success = tdisp_test_set_ide_stream (test_context, PCI_IDE_KM_KEY_SET_K0);
 }
 
-bool tdisp_test_lock_interface_1_run (void *test_context)
+void tdisp_test_lock_interface_1_run (void *test_context)
 {
 	assert_context (test_context);
 
@@ -132,7 +132,7 @@ bool tdisp_test_lock_interface_1_run (void *test_context)
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_lock_interface_1_run get_state failed.\n"));
 
-		return false;
+		return;
 	}
 
 	res = (get_state_response.tdi_state == PCI_TDISP_INTERFACE_STATE_CONFIG_LOCKED);
@@ -140,18 +140,18 @@ bool tdisp_test_lock_interface_1_run (void *test_context)
 	teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[5]);
 
-	return true;
+	return;
 }
 
-bool tdisp_test_lock_interface_1_teardown (void *test_context)
+void tdisp_test_lock_interface_1_teardown (void *test_context)
 {
 	if (setup_success == false) {
-		return true;
+		return;
 	}
 
 	pci_tdisp_stop_interface_response_t response;
 	size_t response_size = sizeof (response);
 
-	return tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
+	tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
 		&response_size);
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_lock_interface_2.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_lock_interface_2.c
@@ -79,7 +79,7 @@ bool tdisp_test_lock_interface_2_setup (void *test_context)
 	return setup_success = true;
 }
 
-bool tdisp_test_lock_interface_2_run (void *test_context)
+void tdisp_test_lock_interface_2_run (void *test_context)
 {
 	assert_context (test_context);
 
@@ -137,7 +137,7 @@ bool tdisp_test_lock_interface_2_run (void *test_context)
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_lock_interface_2_run get_state failed.\n"));
 
-		return false;
+		return;
 	}
 
 	res = (get_state_response.tdi_state ==
@@ -146,18 +146,18 @@ bool tdisp_test_lock_interface_2_run (void *test_context)
 	teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[6]);
 
-	return true;
+	return;
 }
 
-bool tdisp_test_lock_interface_2_teardown (void *test_context)
+void tdisp_test_lock_interface_2_teardown (void *test_context)
 {
 	if (setup_success == false) {
-		return true;
+		return;
 	}
 
 	pci_tdisp_stop_interface_response_t response;
 	size_t response_size = sizeof (response);
 
-	return tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
+	tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
 		&response_size);
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_lock_interface_3.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_lock_interface_3.c
@@ -98,7 +98,7 @@ bool tdisp_test_lock_interface_3_setup (void *test_context)
 	return setup_success = true;
 }
 
-bool tdisp_test_lock_interface_3_run (void *test_context)
+void tdisp_test_lock_interface_3_run (void *test_context)
 {
 	assert_context (test_context);
 
@@ -156,7 +156,7 @@ bool tdisp_test_lock_interface_3_run (void *test_context)
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_lock_interface_3_run get_state failed.\n"));
 
-		return false;
+		return;
 	}
 
 	res = (get_state_response.tdi_state ==
@@ -165,18 +165,18 @@ bool tdisp_test_lock_interface_3_run (void *test_context)
 	teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[6]);
 
-	return true;
+	return;
 }
 
-bool tdisp_test_lock_interface_3_teardown (void *test_context)
+void tdisp_test_lock_interface_3_teardown (void *test_context)
 {
 	if (setup_success == false) {
-		return true;
+		return;
 	}
 
 	pci_tdisp_stop_interface_response_t response;
 	size_t response_size = sizeof (response);
 
-	return tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
+	tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
 		&response_size);
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_lock_interface_4.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_lock_interface_4.c
@@ -110,7 +110,7 @@ bool tdisp_test_lock_interface_4_setup (void *test_context)
 	return setup_success = true;
 }
 
-bool tdisp_test_lock_interface_4_run (void *test_context)
+void tdisp_test_lock_interface_4_run (void *test_context)
 {
 	assert_context (test_context);
 
@@ -168,7 +168,7 @@ bool tdisp_test_lock_interface_4_run (void *test_context)
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_lock_interface_3_run get_state failed.\n"));
 
-		return false;
+		return;
 	}
 
 	res = (get_state_response.tdi_state ==
@@ -177,18 +177,18 @@ bool tdisp_test_lock_interface_4_run (void *test_context)
 	teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[6]);
 
-	return true;
+	return;
 }
 
-bool tdisp_test_lock_interface_4_teardown (void *test_context)
+void tdisp_test_lock_interface_4_teardown (void *test_context)
 {
 	if (setup_success == false) {
-		return true;
+		return;
 	}
 
 	pci_tdisp_stop_interface_response_t response;
 	size_t response_size = sizeof (response);
 
-	return tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
+	tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
 		&response_size);
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_query_1.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_query_1.c
@@ -28,7 +28,7 @@ bool tdisp_test_query_1_setup (void *test_context)
 	return true;
 }
 
-bool tdisp_test_query_1_run (void *test_context)
+void tdisp_test_query_1_run (void *test_context)
 {
 	assert_context (test_context);
 
@@ -82,11 +82,8 @@ bool tdisp_test_query_1_run (void *test_context)
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[6]);
-
-	return true;
 }
 
-bool tdisp_test_query_1_teardown (void *test_context)
+void tdisp_test_query_1_teardown (void *test_context)
 {
-	return true;
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_query_2.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_query_2.c
@@ -52,7 +52,7 @@ bool tdisp_test_query_2_setup (void *test_context)
 	return true;
 }
 
-bool tdisp_test_query_2_run (void *test_context)
+void tdisp_test_query_2_run (void *test_context)
 {
 	assert_context (test_context);
 
@@ -147,11 +147,8 @@ bool tdisp_test_query_2_run (void *test_context)
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 10,
 		IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST, assertion_result, mAssertion[10]);
-
-	return true;
 }
 
-bool tdisp_test_query_2_teardown (void *test_context)
+void tdisp_test_query_2_teardown (void *test_context)
 {
-	return true;
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_start_interface_1.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_start_interface_1.c
@@ -93,7 +93,7 @@ bool tdisp_test_start_interface_1_setup (void *test_context)
 	return setup_success = true;
 }
 
-bool tdisp_test_start_interface_1_run (void *test_context)
+void tdisp_test_start_interface_1_run (void *test_context)
 {
 	assert_context (test_context);
 
@@ -146,26 +146,24 @@ bool tdisp_test_start_interface_1_run (void *test_context)
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_start_interface_1_run get_state failed.\n"));
 
-		return false;
+		return;
 	}
 
 	res = (get_state_response.tdi_state == PCI_TDISP_INTERFACE_STATE_RUN);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[5]);
-
-	return true;
 }
 
-bool tdisp_test_start_interface_1_teardown (void *test_context)
+void tdisp_test_start_interface_1_teardown (void *test_context)
 {
 	if (setup_success == false) {
-		return true;
+		return;
 	}
 
 	pci_tdisp_stop_interface_response_t response;
 	size_t response_size = sizeof (response);
 
-	return tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
+	tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
 		&response_size);
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_start_interface_2.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_start_interface_2.c
@@ -93,7 +93,7 @@ bool tdisp_test_start_interface_2_setup (void *test_context)
 	return setup_success = true;
 }
 
-bool tdisp_test_start_interface_2_run (void *test_context)
+void tdisp_test_start_interface_2_run (void *test_context)
 {
 	assert_context (test_context);
 
@@ -159,26 +159,24 @@ bool tdisp_test_start_interface_2_run (void *test_context)
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_start_interface_2_run get_state failed.\n"));
 
-		return false;
+		return;
 	}
 
 	res = (get_state_response.tdi_state == PCI_TDISP_INTERFACE_STATE_CONFIG_LOCKED);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[6]);
-
-	return true;
 }
 
-bool tdisp_test_start_interface_2_teardown (void *test_context)
+void tdisp_test_start_interface_2_teardown (void *test_context)
 {
 	if (setup_success == false) {
-		return true;
+		return;
 	}
 
 	pci_tdisp_stop_interface_response_t response;
 	size_t response_size = sizeof (response);
 
-	return tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
+	tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
 		&response_size);
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_start_interface_3.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_start_interface_3.c
@@ -105,7 +105,7 @@ bool tdisp_test_start_interface_3_setup (void *test_context)
 	return setup_success = true;
 }
 
-bool tdisp_test_start_interface_3_run (void *test_context)
+void tdisp_test_start_interface_3_run (void *test_context)
 {
 	assert_context (test_context);
 
@@ -163,26 +163,24 @@ bool tdisp_test_start_interface_3_run (void *test_context)
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_start_interface_3_run get_state failed.\n"));
 
-		return false;
+		return;
 	}
 
 	res = (get_state_response.tdi_state == PCI_TDISP_INTERFACE_STATE_CONFIG_UNLOCKED);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[6]);
-
-	return true;
 }
 
-bool tdisp_test_start_interface_3_teardown (void *test_context)
+void tdisp_test_start_interface_3_teardown (void *test_context)
 {
 	if (setup_success == false) {
-		return true;
+		return;
 	}
 
 	pci_tdisp_stop_interface_response_t response;
 	size_t response_size = sizeof (response);
 
-	return tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
+	tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
 		&response_size);
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_start_interface_4.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_start_interface_4.c
@@ -105,7 +105,7 @@ bool tdisp_test_start_interface_4_setup (void *test_context)
 	return setup_success = true;
 }
 
-bool tdisp_test_start_interface_4_run (void *test_context)
+void tdisp_test_start_interface_4_run (void *test_context)
 {
 	assert_context (test_context);
 
@@ -163,26 +163,24 @@ bool tdisp_test_start_interface_4_run (void *test_context)
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_start_interface_4_run get_state failed.\n"));
 
-		return false;
+		return;
 	}
 
 	res = (get_state_response.tdi_state == PCI_TDISP_INTERFACE_STATE_RUN);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[6]);
-
-	return true;
 }
 
-bool tdisp_test_start_interface_4_teardown (void *test_context)
+void tdisp_test_start_interface_4_teardown (void *test_context)
 {
 	if (setup_success == false) {
-		return true;
+		return;
 	}
 
 	pci_tdisp_stop_interface_response_t response;
 	size_t response_size = sizeof (response);
 
-	return tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
+	tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
 		&response_size);
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_stop_interface_1.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_stop_interface_1.c
@@ -109,7 +109,7 @@ bool tdisp_test_stop_interface_1_setup (void *test_context)
 	return setup_success = true;
 }
 
-bool tdisp_test_stop_interface_1_run (void *test_context)
+void tdisp_test_stop_interface_1_run (void *test_context)
 {
 	assert_context (test_context);
 
@@ -162,7 +162,7 @@ bool tdisp_test_stop_interface_1_run (void *test_context)
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_stop_interface_1_run get_state failed.\n"));
 
-		return false;
+		return;
 	}
 
 	res = (get_state_response.tdi_state ==
@@ -170,19 +170,17 @@ bool tdisp_test_stop_interface_1_run (void *test_context)
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[5]);
-
-	return true;
 }
 
-bool tdisp_test_stop_interface_1_teardown (void *test_context)
+void tdisp_test_stop_interface_1_teardown (void *test_context)
 {
 	if (setup_success == false) {
-		return true;
+		return;
 	}
 
 	pci_tdisp_stop_interface_response_t response;
 	size_t response_size = sizeof (response);
 
-	return tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
+	tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
 		&response_size);
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_stop_interface_2.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_stop_interface_2.c
@@ -97,7 +97,7 @@ bool tdisp_test_stop_interface_2_setup (void *test_context)
 	return setup_success = true;
 }
 
-bool tdisp_test_stop_interface_2_run (void *test_context)
+void tdisp_test_stop_interface_2_run (void *test_context)
 {
 	assert_context (test_context);
 
@@ -150,7 +150,7 @@ bool tdisp_test_stop_interface_2_run (void *test_context)
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_stop_interface_2_run get_state failed.\n"));
 
-		return false;
+		return;
 	}
 
 	res = (get_state_response.tdi_state ==
@@ -158,19 +158,17 @@ bool tdisp_test_stop_interface_2_run (void *test_context)
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[5]);
-
-	return true;
 }
 
-bool tdisp_test_stop_interface_2_teardown (void *test_context)
+void tdisp_test_stop_interface_2_teardown (void *test_context)
 {
 	if (setup_success == false) {
-		return true;
+		return;
 	}
 
 	pci_tdisp_stop_interface_response_t response;
 	size_t response_size = sizeof (response);
 
-	return tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
+	tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
 		&response_size);
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_stop_interface_3.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_stop_interface_3.c
@@ -81,7 +81,7 @@ bool tdisp_test_stop_interface_3_setup (void *test_context)
 	return setup_success = true;
 }
 
-bool tdisp_test_stop_interface_3_run (void *test_context)
+void tdisp_test_stop_interface_3_run (void *test_context)
 {
 	assert_context (test_context);
 
@@ -134,7 +134,7 @@ bool tdisp_test_stop_interface_3_run (void *test_context)
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_stop_interface_2_run get_state failed.\n"));
 
-		return false;
+		return;
 	}
 
 	res = (get_state_response.tdi_state ==
@@ -142,19 +142,17 @@ bool tdisp_test_stop_interface_3_run (void *test_context)
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[5]);
-
-	return true;
 }
 
-bool tdisp_test_stop_interface_3_teardown (void *test_context)
+void tdisp_test_stop_interface_3_teardown (void *test_context)
 {
 	if (setup_success == false) {
-		return true;
+		return;
 	}
 
 	pci_tdisp_stop_interface_response_t response;
 	size_t response_size = sizeof (response);
 
-	return tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
+	tdisp_test_stop_interface (test_context, g_tdisp_interface_id.function_id, &response,
 		&response_size);
 }


### PR DESCRIPTION
Fix #286 

Redefine below 2 functions' return as void.
 - ide_common_test_case_run_func_t
 - ide_common_test_case_teardown_func_t