### PR TITLE
Refine assersion messages in TDISP test cases

### DIFF
--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_report_1.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_report_1.c
@@ -13,7 +13,7 @@
 extern pci_tdisp_interface_id_t g_tdisp_interface_id;
 
 static const char *mAssertion[] = {
-	"TdispMessage.TDI_STATE == CONFIG_LOCKED"
+	"TdispMessage.TDI_STATE = 0x%x"
 };
 static bool setup_success = false;
 
@@ -116,6 +116,8 @@ void tdisp_test_interface_report_1_run (void *test_context)
 		&response_size)) {
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_interface_report_1_run get_state failed.\n"));
+		teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
+			TEEIO_TEST_RESULT_FAILED, "tdisp_test_get_state failed.");
 
 		return;
 	}
@@ -124,7 +126,7 @@ void tdisp_test_interface_report_1_run (void *test_context)
 	teeio_test_result_t assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 
 	teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[0]);
+		assertion_result, mAssertion[0], get_state_response.tdi_state);
 }
 
 void tdisp_test_interface_report_1_teardown (void *test_context)

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_report_2.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_report_2.c
@@ -13,7 +13,7 @@
 extern pci_tdisp_interface_id_t g_tdisp_interface_id;
 
 static const char *mAssertion[] = {
-	"TdispMessage.TDI_STATE == RUN"
+	"TdispMessage.TDI_STATE = 0x%x"
 };
 static bool setup_success = false;
 
@@ -128,6 +128,8 @@ void tdisp_test_interface_report_2_run (void *test_context)
 		&response_size)) {
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_interface_report_2_run get_state failed.\n"));
+		teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
+			TEEIO_TEST_RESULT_FAILED, "tdisp_test_get_state failed.");
 
 		return;
 	}
@@ -136,7 +138,7 @@ void tdisp_test_interface_report_2_run (void *test_context)
 	teeio_test_result_t assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 
 	teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[0]);
+		assertion_result, mAssertion[0], get_state_response.tdi_state);
 
 	return;
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_report_3.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_report_3.c
@@ -18,13 +18,13 @@
 extern pci_tdisp_interface_id_t g_tdisp_interface_id;
 
 static const char *mAssertion[] = {
-	"tdisp_query send_receive_data",
-	"sizeof(TdispMessage) == sizeof(TDISP_ERROR)",
-	"TdispMessage.TDISPVersion == 0x10",
-	"TdispMessage.MessageType == TDISP_ERROR",
-	"TdispMessage.INTERFACE_ID == LOCK_INTERFACE_REQUEST.INTERFACE_ID",
-	"TdispMessage.ERROR_CODE == INVALID_REQUEST",
-	"TdispMessage.TDI_STATE == CONFIG_LOCKED"
+	"tdisp_send_receive_data",
+	"sizeof(TdispMessage) = 0x%x",
+	"TdispMessage.TDISPVersion = 0x%x",
+	"TdispMessage.MessageType = 0x%x",
+	"TdispMessage.INTERFACE_ID = 0x%x",
+	"TdispMessage.ERROR_CODE = 0x%x",
+	"TdispMessage.TDI_STATE = 0x%x"
 };
 static bool setup_success = false;
 
@@ -135,33 +135,39 @@ void tdisp_test_interface_report_3_run (void *test_context)
 	bool res = !LIBSPDM_STATUS_IS_ERROR (status);
 	teeio_test_result_t assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 
-	teeio_record_assertion_result (case_class, case_id, 0, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[0]);
+	if(!res) {
+		teeio_record_assertion_result (case_class, case_id, 0, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
+			assertion_result, mAssertion[0]);
+		return;
+	}
 
 	res = (response_size == sizeof (pci_tdisp_error_response_t));
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 1, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[1]);
+		assertion_result, mAssertion[1], response_size);
+	if(!res) {
+		return;
+	}
 
 	res = (response.header.version == PCI_TDISP_MESSAGE_VERSION_10);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 2, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[2]);
+		assertion_result, mAssertion[2], response.header.version);
 
 	res = (response.header.message_type == PCI_TDISP_ERROR);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 3, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[3]);
+		assertion_result, mAssertion[3], response.header.message_type);
 
 	res = (response.header.interface_id.function_id == g_tdisp_interface_id.function_id);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 4, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[4]);
+		assertion_result, mAssertion[4], response.header.interface_id.function_id);
 
 	res = (response.error_code == PCI_TDISP_ERROR_CODE_INVALID_REQUEST);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[5]);
+		assertion_result, mAssertion[5], response.error_code);
 
 	pci_tdisp_device_interface_state_response_t get_state_response;
 
@@ -170,6 +176,8 @@ void tdisp_test_interface_report_3_run (void *test_context)
 		&response_size)) {
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_lock_interface_3_run get_state failed.\n"));
+		teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
+			TEEIO_TEST_RESULT_FAILED, "tdisp_test_get_state failed.");
 
 		return;
 	}
@@ -177,7 +185,7 @@ void tdisp_test_interface_report_3_run (void *test_context)
 	res = (get_state_response.tdi_state == PCI_TDISP_INTERFACE_STATE_CONFIG_LOCKED);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[6]);
+		assertion_result, mAssertion[6], get_state_response.tdi_state);
 
 	return;
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_report_5.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_report_5.c
@@ -13,9 +13,9 @@
 extern pci_tdisp_interface_id_t g_tdisp_interface_id;
 
 static const char *mAssertion[] = {
-	"sizeof(REPORT_BYTES) == sizeof(REPORT_BYTES, DEVICE_SPECIFIC_INFO) + REPORT_BYTES.DEVICE_SPECIFIC_INFO_LEN",
-	"(REPORT_BYTES.INTERFACE_INFO & 0xFFE0) == 0",
-	"(REPORT_BYTES.MMIO_RANGE[i].RangeAttributes & 0xFFF0) == 0"
+	"sizeof(REPORT_BYTES) = 0x%x",
+	"(REPORT_BYTES.INTERFACE_INFO & 0xFFE0) = 0x%x",
+	"(REPORT_BYTES.MMIO_RANGE[i].RangeAttributes & 0xFFF0) = 0x%x"
 };
 static bool setup_success = false;
 
@@ -136,11 +136,14 @@ void tdisp_test_interface_report_5_run (void *test_context)
 
 	teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[0]);
+	if(!res) {
+		return;
+	}
 
 	res = ((interface_info & 0xFFE0) == 0);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 7, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[1]);
+		assertion_result, mAssertion[1], interface_info & 0xFFE0);
 
 	for (uint32_t i = 0; i < mmio_range_count; ++i) {
 		data32.byte0 = interface_report_buffer[16 +
@@ -156,7 +159,7 @@ void tdisp_test_interface_report_5_run (void *test_context)
 		res = ((range_attributes & 0xFFF0) == 0);
 		assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 		teeio_record_assertion_result (case_class, case_id, 8,
-			IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST, assertion_result, mAssertion[2]);
+			IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST, assertion_result, mAssertion[2], range_attributes & 0xFFF0);
 	}
 
 	return;

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_state_1.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_state_1.c
@@ -11,12 +11,12 @@
 extern pci_tdisp_interface_id_t g_tdisp_interface_id;
 
 static const char *mAssertion[] = {
-	"tdisp_query send_receive_data",
-	"sizeof(TdispMessage) == sizeof(DEVICE_INTERFACE_STATE)",
-	"TdispMessage.TDISPVersion == 0x10",
-	"TdispMessage.MessageType == DEVICE_INTERFACE_STATE",
-	"TdispMessage.INTERFACE_ID == GET_DEVICE_INTERFACE_STATE.INTERFACE_ID",
-	"TdispMessage.TDI_STATE == CONFIG_UNLOCKED"
+	"tdisp_send_receive_data",
+	"sizeof(TdispMessage) = 0x%x",
+	"TdispMessage.TDISPVersion = 0x%x",
+	"TdispMessage.MessageType = 0x%x",
+	"TdispMessage.INTERFACE_ID = 0x%x",
+	"TdispMessage.TDI_STATE = 0x%x"
 };
 static bool setup_success = false;
 
@@ -74,31 +74,37 @@ void tdisp_test_interface_state_1_run (void *test_context)
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 0, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[0]);
+	if(!res) {
+		return;
+	}
 
 	res = (response_size == sizeof (pci_tdisp_device_interface_state_response_t));
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 1, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[1]);
+		assertion_result, mAssertion[1], response_size);
+	if(!res) {
+		return;
+	}
 
 	res = (response.header.version == PCI_TDISP_MESSAGE_VERSION_10);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 2, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[2]);
+		assertion_result, mAssertion[2], response.header.version);
 
 	res = (response.header.message_type == PCI_TDISP_DEVICE_INTERFACE_STATE);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 3, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[3]);
+		assertion_result, mAssertion[3], response.header.message_type);
 
 	res = (response.header.interface_id.function_id == g_tdisp_interface_id.function_id);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 4, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[4]);
+		assertion_result, mAssertion[4], response.header.interface_id.function_id);
 
 	res = (response.tdi_state == PCI_TDISP_INTERFACE_STATE_CONFIG_UNLOCKED);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[5]);
+		assertion_result, mAssertion[5], response.tdi_state);
 
 	return;
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_state_2.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_state_2.c
@@ -12,12 +12,12 @@
 extern pci_tdisp_interface_id_t g_tdisp_interface_id;
 
 static const char *mAssertion[] = {
-	"tdisp_query send_receive_data",
-	"sizeof(TdispMessage) == sizeof(DEVICE_INTERFACE_STATE)",
-	"TdispMessage.TDISPVersion == 0x10",
-	"TdispMessage.MessageType == DEVICE_INTERFACE_STATE",
-	"TdispMessage.INTERFACE_ID == GET_DEVICE_INTERFACE_STATE.INTERFACE_ID",
-	"TdispMessage.TDI_STATE == CONFIG_LOCKED"
+	"tdisp_send_receive_data",
+	"sizeof(TdispMessage) = 0x%x",
+	"TdispMessage.TDISPVersion = 0x%x",
+	"TdispMessage.MessageType = 0x%x",
+	"TdispMessage.INTERFACE_ID = 0x%x",
+	"TdispMessage.TDI_STATE = 0x%x"
 };
 static bool setup_success = false;
 
@@ -94,31 +94,37 @@ void tdisp_test_interface_state_2_run (void *test_context)
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 0, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[0]);
+	if(!res) {
+		return;
+	}
 
 	res = (response_size == sizeof (pci_tdisp_device_interface_state_response_t));
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 1, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[1]);
+		assertion_result, mAssertion[1], response_size);
+	if(!res) {
+		return;
+	}
 
 	res = (response.header.version == PCI_TDISP_MESSAGE_VERSION_10);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 2, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[2]);
+		assertion_result, mAssertion[2], response.header.version);
 
 	res = (response.header.message_type == PCI_TDISP_DEVICE_INTERFACE_STATE);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 3, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[3]);
+		assertion_result, mAssertion[3], response.header.message_type);
 
 	res = (response.header.interface_id.function_id == g_tdisp_interface_id.function_id);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 4, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[4]);
+		assertion_result, mAssertion[4], response.header.interface_id.function_id);
 
 	res = (response.tdi_state == PCI_TDISP_INTERFACE_STATE_CONFIG_LOCKED);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[5]);
+		assertion_result, mAssertion[5], response.tdi_state);
 
 	return;
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_state_3.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_state_3.c
@@ -12,12 +12,12 @@
 extern pci_tdisp_interface_id_t g_tdisp_interface_id;
 
 static const char *mAssertion[] = {
-	"tdisp_query send_receive_data",
-	"sizeof(TdispMessage) == sizeof(DEVICE_INTERFACE_STATE)",
-	"TdispMessage.TDISPVersion == 0x10",
-	"TdispMessage.MessageType == DEVICE_INTERFACE_STATE",
-	"TdispMessage.INTERFACE_ID == GET_DEVICE_INTERFACE_STATE.INTERFACE_ID",
-	"TdispMessage.TDI_STATE == RUN"
+	"tdisp_send_receive_data",
+	"sizeof(TdispMessage) = 0x%x",
+	"TdispMessage.TDISPVersion = 0x%x",
+	"TdispMessage.MessageType = 0x%x",
+	"TdispMessage.INTERFACE_ID = 0x%x",
+	"TdispMessage.TDI_STATE = 0x%x"
 };
 static bool setup_success = false;
 
@@ -106,31 +106,37 @@ void tdisp_test_interface_state_3_run (void *test_context)
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 0, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[0]);
+	if(!res) {
+		return;
+	}
 
 	res = (response_size == sizeof (pci_tdisp_device_interface_state_response_t));
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 1, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[1]);
+		assertion_result, mAssertion[1], response_size);
+	if(!res) {
+		return;
+	}
 
 	res = (response.header.version == PCI_TDISP_MESSAGE_VERSION_10);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 2, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[2]);
+		assertion_result, mAssertion[2], response.header.version);
 
 	res = (response.header.message_type == PCI_TDISP_DEVICE_INTERFACE_STATE);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 3, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[3]);
+		assertion_result, mAssertion[3], response.header.message_type);
 
 	res = (response.header.interface_id.function_id == g_tdisp_interface_id.function_id);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 4, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[4]);
+		assertion_result, mAssertion[4], response.header.interface_id.function_id);
 
 	res = (response.tdi_state == PCI_TDISP_INTERFACE_STATE_RUN);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[5]);
+		assertion_result, mAssertion[5], response.tdi_state);
 
 	return;
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_state_4.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_interface_state_4.c
@@ -12,12 +12,12 @@
 extern pci_tdisp_interface_id_t g_tdisp_interface_id;
 
 static const char *mAssertion[] = {
-	"tdisp_query send_receive_data",
-	"sizeof(TdispMessage) == sizeof(DEVICE_INTERFACE_STATE)",
-	"TdispMessage.TDISPVersion == 0x10",
-	"TdispMessage.MessageType == DEVICE_INTERFACE_STATE",
-	"TdispMessage.INTERFACE_ID == GET_DEVICE_INTERFACE_STATE.INTERFACE_ID",
-	"TdispMessage.TDI_STATE == CONFIG_UNLOCKED"
+	"tdisp_send_receive_data",
+	"sizeof(TdispMessage) = 0x%x",
+	"TdispMessage.TDISPVersion = 0x%x",
+	"TdispMessage.MessageType = 0x%x",
+	"TdispMessage.INTERFACE_ID = 0x%x",
+	"TdispMessage.TDI_STATE = 0x%x",
 };
 static bool setup_success = false;
 
@@ -118,31 +118,37 @@ void tdisp_test_interface_state_4_run (void *test_context)
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 0, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[0]);
+	if(!res) {
+		return;
+	}
 
 	res = (response_size == sizeof (pci_tdisp_device_interface_state_response_t));
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 1, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[1]);
+		assertion_result, mAssertion[1], response_size);
+	if(!res) {
+		return;
+	}
 
 	res = (response.header.version == PCI_TDISP_MESSAGE_VERSION_10);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 2, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[2]);
+		assertion_result, mAssertion[2], response.header.version);
 
 	res = (response.header.message_type == PCI_TDISP_DEVICE_INTERFACE_STATE);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 3, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[3]);
+		assertion_result, mAssertion[3], response.header.message_type);
 
 	res = (response.header.interface_id.function_id == g_tdisp_interface_id.function_id);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 4, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[4]);
+		assertion_result, mAssertion[4], response.header.interface_id.function_id);
 
 	res = (response.tdi_state == PCI_TDISP_INTERFACE_STATE_CONFIG_UNLOCKED);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[5]);
+		assertion_result, mAssertion[5], response.tdi_state);
 
 	return;
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_lock_interface_1.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_lock_interface_1.c
@@ -13,12 +13,12 @@
 extern pci_tdisp_interface_id_t g_tdisp_interface_id;
 
 static const char *mAssertion[] = {
-	"tdisp_query send_receive_data",
-	"sizeof(TdispMessage) == sizeof(LOCK_INTERFACE_RESPONSE)",
-	"TdispMessage.TDISPVersion == 0x10",
-	"TdispMessage.MessageType == LOCK_INTERFACE_RESPONSE",
-	"TdispMessage.INTERFACE_ID == LOCK_INTERFACE_REQUEST.INTERFACE_ID",
-	"TdispMessage.TDI_STATE == CONFIG_LOCKED"
+	"tdisp_send_receive_data",
+	"sizeof(TdispMessage) = 0x%x",
+	"TdispMessage.TDISPVersion = 0x%x",
+	"TdispMessage.MessageType = 0x%x",
+	"TdispMessage.INTERFACE_ID = 0x%x",
+	"TdispMessage.TDI_STATE = 0x%x"
 };
 static pci_tdisp_responder_capabilities_t rsp_caps = {0};
 static bool setup_success = false;
@@ -103,26 +103,32 @@ void tdisp_test_lock_interface_1_run (void *test_context)
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 0, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[0]);
+	if(!res) {
+		return;
+	}
 
 	res = (response_size == sizeof (pci_tdisp_lock_interface_response_t));
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 1, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[1]);
+		assertion_result, mAssertion[1], response_size);
+	if(!res) {
+		return;
+	}
 
 	res = (response.header.version == PCI_TDISP_MESSAGE_VERSION_10);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 2, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[2]);
+		assertion_result, mAssertion[2], response.header.version);
 
 	res = (response.header.message_type == PCI_TDISP_LOCK_INTERFACE_RSP);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 3, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[3]);
+		assertion_result, mAssertion[3], response.header.message_type);
 
 	res = (response.header.interface_id.function_id == g_tdisp_interface_id.function_id);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 4, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[4]);
+		assertion_result, mAssertion[4], response.header.interface_id.function_id);
 
 	pci_tdisp_device_interface_state_response_t get_state_response;
 
@@ -131,6 +137,8 @@ void tdisp_test_lock_interface_1_run (void *test_context)
 		&response_size)) {
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_lock_interface_1_run get_state failed.\n"));
+		teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
+			TEEIO_TEST_RESULT_FAILED, "tdisp_test_get_state failed.");
 
 		return;
 	}
@@ -138,7 +146,7 @@ void tdisp_test_lock_interface_1_run (void *test_context)
 	res = (get_state_response.tdi_state == PCI_TDISP_INTERFACE_STATE_CONFIG_LOCKED);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[5]);
+		assertion_result, mAssertion[5], get_state_response.tdi_state);
 
 	return;
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_lock_interface_2.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_lock_interface_2.c
@@ -12,13 +12,13 @@
 extern pci_tdisp_interface_id_t g_tdisp_interface_id;
 
 static const char *mAssertion[] = {
-	"tdisp_query send_receive_data",
-	"sizeof(TdispMessage) == sizeof(TDISP_ERROR)",
-	"TdispMessage.TDISPVersion == 0x10",
-	"TdispMessage.MessageType == TDISP_ERROR",
-	"TdispMessage.INTERFACE_ID == LOCK_INTERFACE_REQUEST.INTERFACE_ID",
-	"TdispMessage.ERROR_CODE == INVALID_REQUEST",
-	"TdispMessage.TDI_STATE == CONFIG_UNLOCKED"
+	"tdisp_send_receive_data",
+	"sizeof(TdispMessage) = 0x%x",
+	"TdispMessage.TDISPVersion = 0x%x",
+	"TdispMessage.MessageType = 0x%x",
+	"TdispMessage.INTERFACE_ID = 0x%x",
+	"TdispMessage.ERROR_CODE = 0x%x",
+	"TdispMessage.TDI_STATE = 0x%x"
 };
 static pci_tdisp_responder_capabilities_t rsp_caps = {0};
 static bool setup_success = false;
@@ -103,31 +103,37 @@ void tdisp_test_lock_interface_2_run (void *test_context)
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 0, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[0]);
+	if(!res) {
+		return;
+	}
 
 	res = (response_size == sizeof (pci_tdisp_error_response_t));
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 1, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[1]);
+		assertion_result, mAssertion[1], response_size);
+	if(!res) {
+		return;
+	}
 
 	res = (response.header.version == PCI_TDISP_MESSAGE_VERSION_10);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 2, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[2]);
+		assertion_result, mAssertion[2], response.header.version);
 
 	res = (response.header.message_type == PCI_TDISP_ERROR);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 3, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[3]);
+		assertion_result, mAssertion[3], response.header.message_type);
 
 	res = (response.header.interface_id.function_id == g_tdisp_interface_id.function_id);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 4, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[4]);
+		assertion_result, mAssertion[4], response.header.interface_id.function_id);
 
 	res = (response.error_code == PCI_TDISP_ERROR_CODE_INVALID_REQUEST);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[5]);
+		assertion_result, mAssertion[5], response.error_code);
 
 	pci_tdisp_device_interface_state_response_t get_state_response;
 
@@ -136,6 +142,8 @@ void tdisp_test_lock_interface_2_run (void *test_context)
 		&response_size)) {
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_lock_interface_2_run get_state failed.\n"));
+		teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
+			TEEIO_TEST_RESULT_FAILED, "tdisp_test_get_state failed.");
 
 		return;
 	}
@@ -144,7 +152,7 @@ void tdisp_test_lock_interface_2_run (void *test_context)
 		PCI_TDISP_INTERFACE_STATE_CONFIG_UNLOCKED);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[6]);
+		assertion_result, mAssertion[6], get_state_response.tdi_state);
 
 	return;
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_lock_interface_3.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_lock_interface_3.c
@@ -13,13 +13,13 @@
 extern pci_tdisp_interface_id_t g_tdisp_interface_id;
 
 static const char *mAssertion[] = {
-	"tdisp_query send_receive_data",
-	"sizeof(TdispMessage) == sizeof(TDISP_ERROR)",
-	"TdispMessage.TDISPVersion == 0x10",
-	"TdispMessage.MessageType == TDISP_ERROR",
-	"TdispMessage.INTERFACE_ID == LOCK_INTERFACE_REQUEST.INTERFACE_ID",
-	"TdispMessage.ERROR_CODE == INVALID_INTERFACE_STATE",
-	"TdispMessage.TDI_STATE == CONFIG_LOCKED"
+	"tdisp_send_receive_data",
+	"sizeof(TdispMessage) = 0x%x",
+	"TdispMessage.TDISPVersion = 0x%x",
+	"TdispMessage.MessageType = 0x%x",
+	"TdispMessage.INTERFACE_ID = 0x%x",
+	"TdispMessage.ERROR_CODE = 0x%x",
+	"TdispMessage.TDI_STATE = 0x%x"
 };
 static pci_tdisp_responder_capabilities_t rsp_caps = {0};
 static bool setup_success = false;
@@ -122,31 +122,37 @@ void tdisp_test_lock_interface_3_run (void *test_context)
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 0, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[0]);
+	if(!res) {
+		return;
+	}
 
 	res = (response_size == sizeof (pci_tdisp_error_response_t));
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 1, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[1]);
+		assertion_result, mAssertion[1], response_size);
+	if(!res) {
+		return;
+	}
 
 	res = (response.header.version == PCI_TDISP_MESSAGE_VERSION_10);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 2, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[2]);
+		assertion_result, mAssertion[2], response.header.version);
 
 	res = (response.header.message_type == PCI_TDISP_ERROR);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 3, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[3]);
+		assertion_result, mAssertion[3], response.header.message_type);
 
 	res = (response.header.interface_id.function_id == g_tdisp_interface_id.function_id);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 4, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[4]);
+		assertion_result, mAssertion[4], response.header.interface_id.function_id);
 
 	res = (response.error_code == PCI_TDISP_ERROR_CODE_INVALID_INTERFACE_STATE);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[5]);
+		assertion_result, mAssertion[5], response.error_code);
 
 	pci_tdisp_device_interface_state_response_t get_state_response;
 
@@ -155,6 +161,8 @@ void tdisp_test_lock_interface_3_run (void *test_context)
 		&response_size)) {
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_lock_interface_3_run get_state failed.\n"));
+		teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
+			TEEIO_TEST_RESULT_FAILED, "tdisp_test_get_state failed.");
 
 		return;
 	}
@@ -163,7 +171,7 @@ void tdisp_test_lock_interface_3_run (void *test_context)
 		PCI_TDISP_INTERFACE_STATE_CONFIG_LOCKED);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[6]);
+		assertion_result, mAssertion[6], get_state_response.tdi_state);
 
 	return;
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_lock_interface_4.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_lock_interface_4.c
@@ -13,13 +13,13 @@
 extern pci_tdisp_interface_id_t g_tdisp_interface_id;
 
 static const char *mAssertion[] = {
-	"tdisp_query send_receive_data",
-	"sizeof(TdispMessage) == sizeof(TDISP_ERROR)",
-	"TdispMessage.TDISPVersion == 0x10",
-	"TdispMessage.MessageType == TDISP_ERROR",
-	"TdispMessage.INTERFACE_ID == LOCK_INTERFACE_REQUEST.INTERFACE_ID",
-	"TdispMessage.ERROR_CODE == INVALID_INTERFACE_STATE",
-	"TdispMessage.TDI_STATE == RUN"
+	"tdisp_send_receive_data",
+	"sizeof(TdispMessage) = 0x%x",
+	"TdispMessage.TDISPVersion = 0x%x",
+	"TdispMessage.MessageType = 0x%x",
+	"TdispMessage.INTERFACE_ID = 0x%x",
+	"TdispMessage.ERROR_CODE = 0x%x",
+	"TdispMessage.TDI_STATE = 0x%x"
 };
 static pci_tdisp_responder_capabilities_t rsp_caps = {0};
 static bool setup_success = false;
@@ -134,31 +134,37 @@ void tdisp_test_lock_interface_4_run (void *test_context)
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 0, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[0]);
+	if(!res) {
+		return;
+	}
 
 	res = (response_size == sizeof (pci_tdisp_error_response_t));
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 1, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[1]);
+		assertion_result, mAssertion[1], response_size);
+	if(!res) {
+		return;
+	}
 
 	res = (response.header.version == PCI_TDISP_MESSAGE_VERSION_10);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 2, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[2]);
+		assertion_result, mAssertion[2], response.header.version);
 
 	res = (response.header.message_type == PCI_TDISP_ERROR);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 3, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[3]);
+		assertion_result, mAssertion[3], response.header.message_type);
 
 	res = (response.header.interface_id.function_id == g_tdisp_interface_id.function_id);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 4, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[4]);
+		assertion_result, mAssertion[4], response.header.interface_id.function_id);
 
 	res = (response.error_code == PCI_TDISP_ERROR_CODE_INVALID_INTERFACE_STATE);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[5]);
+		assertion_result, mAssertion[5], response.error_code);
 
 	pci_tdisp_device_interface_state_response_t get_state_response;
 
@@ -167,6 +173,8 @@ void tdisp_test_lock_interface_4_run (void *test_context)
 		&response_size)) {
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_lock_interface_3_run get_state failed.\n"));
+		teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
+			TEEIO_TEST_RESULT_FAILED, "tdisp_test_get_state failed.");
 
 		return;
 	}
@@ -175,7 +183,7 @@ void tdisp_test_lock_interface_4_run (void *test_context)
 		PCI_TDISP_INTERFACE_STATE_RUN);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[6]);
+		assertion_result, mAssertion[6], get_state_response.tdi_state);
 
 	return;
 }

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_start_interface_1.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_start_interface_1.c
@@ -13,12 +13,12 @@
 extern pci_tdisp_interface_id_t g_tdisp_interface_id;
 
 static const char *mAssertion[] = {
-	"tdisp_query send_receive_data",
-	"sizeof(TdispMessage) == sizeof(START_INTERFACE_RESPONSE)",
-	"TdispMessage.TDISPVersion == 0x10",
-	"TdispMessage.MessageType == START_INTERFACE_RESPONSE",
-	"TdispMessage.INTERFACE_ID == START_INTERFACE_REQUEST.INTERFACE_ID",
-	"TdispMessage.TDI_STATE == RUN"
+	"tdisp_send_receive_data",
+	"sizeof(TdispMessage) = 0x%x",
+	"TdispMessage.TDISPVersion = 0x%x",
+	"TdispMessage.MessageType = 0x%x",
+	"TdispMessage.INTERFACE_ID = 0x%x",
+	"TdispMessage.TDI_STATE = 0x%x"
 };
 static pci_tdisp_lock_interface_response_t lock_interface_response = {0};
 static bool setup_success = false;
@@ -117,26 +117,32 @@ void tdisp_test_start_interface_1_run (void *test_context)
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 0, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[0]);
+	if(!res) {
+		return;
+	}
 
 	res = (response_size == sizeof (pci_tdisp_start_interface_response_t));
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 1, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[1]);
+		assertion_result, mAssertion[1], response_size);
+	if(!res) {
+		return;
+	}
 
 	res = (response.header.version == PCI_TDISP_MESSAGE_VERSION_10);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 2, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[2]);
+		assertion_result, mAssertion[2], response.header.version);
 
 	res = (response.header.message_type == PCI_TDISP_START_INTERFACE_RSP);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 3, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[3]);
+		assertion_result, mAssertion[3], response.header.message_type);
 
 	res = (response.header.interface_id.function_id == g_tdisp_interface_id.function_id);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 4, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[4]);
+		assertion_result, mAssertion[4], response.header.interface_id.function_id);
 
 	pci_tdisp_device_interface_state_response_t get_state_response;
 
@@ -145,6 +151,8 @@ void tdisp_test_start_interface_1_run (void *test_context)
 		&response_size)) {
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_start_interface_1_run get_state failed.\n"));
+		teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
+			TEEIO_TEST_RESULT_FAILED, "tdisp_test_get_state failed.");
 
 		return;
 	}
@@ -152,7 +160,7 @@ void tdisp_test_start_interface_1_run (void *test_context)
 	res = (get_state_response.tdi_state == PCI_TDISP_INTERFACE_STATE_RUN);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[5]);
+		assertion_result, mAssertion[5], get_state_response.tdi_state);
 }
 
 void tdisp_test_start_interface_1_teardown (void *test_context)

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_start_interface_2.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_start_interface_2.c
@@ -13,13 +13,13 @@
 extern pci_tdisp_interface_id_t g_tdisp_interface_id;
 
 static const char *mAssertion[] = {
-	"tdisp_query send_receive_data",
-	"sizeof(TdispMessage) == sizeof(TDISP_ERROR)",
-	"TdispMessage.TDISPVersion == 0x10",
-	"TdispMessage.MessageType == TDISP_ERROR",
-	"TdispMessage.INTERFACE_ID == START_INTERFACE_REQUEST.INTERFACE_ID",
-	"TdispMessage.ERROR_CODE == INVALID_NONCE",
-	"TdispMessage.TDI_STATE == CONFIG_LOCKED"
+	"tdisp_send_receive_data",
+	"sizeof(TdispMessage) = 0x%x",
+	"TdispMessage.TDISPVersion = 0x%x",
+	"TdispMessage.MessageType = 0x%x",
+	"TdispMessage.INTERFACE_ID = 0x%x",
+	"TdispMessage.ERROR_CODE = 0x%x",
+	"TdispMessage.TDI_STATE = 0x%x"
 };
 static pci_tdisp_lock_interface_response_t lock_interface_response = {0};
 static bool setup_success = false;
@@ -125,31 +125,37 @@ void tdisp_test_start_interface_2_run (void *test_context)
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 0, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[0]);
+	if(!res) {
+		return;
+	}
 
 	res = (response_size == sizeof (pci_tdisp_error_response_t));
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 1, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[1]);
+		assertion_result, mAssertion[1], response_size);
+	if(!res) {
+		return;
+	}
 
 	res = (response.header.version == PCI_TDISP_MESSAGE_VERSION_10);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 2, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[2]);
+		assertion_result, mAssertion[2], response.header.version);
 
 	res = (response.header.message_type == PCI_TDISP_ERROR);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 3, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[3]);
+		assertion_result, mAssertion[3], response.header.message_type);
 
 	res = (response.header.interface_id.function_id == g_tdisp_interface_id.function_id);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 4, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[4]);
+		assertion_result, mAssertion[4], response.header.interface_id.function_id);
 
 	res = (response.error_code == PCI_TDISP_ERROR_CODE_INVALID_NONCE);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[5]);
+		assertion_result, mAssertion[5], response.error_code);
 
 	pci_tdisp_device_interface_state_response_t get_state_response;
 
@@ -158,6 +164,8 @@ void tdisp_test_start_interface_2_run (void *test_context)
 		&response_size)) {
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_start_interface_2_run get_state failed.\n"));
+		teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
+			TEEIO_TEST_RESULT_FAILED, "tdisp_test_get_state failed.");
 
 		return;
 	}
@@ -165,7 +173,7 @@ void tdisp_test_start_interface_2_run (void *test_context)
 	res = (get_state_response.tdi_state == PCI_TDISP_INTERFACE_STATE_CONFIG_LOCKED);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[6]);
+		assertion_result, mAssertion[6], get_state_response.tdi_state);
 }
 
 void tdisp_test_start_interface_2_teardown (void *test_context)

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_start_interface_3.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_start_interface_3.c
@@ -13,13 +13,13 @@
 extern pci_tdisp_interface_id_t g_tdisp_interface_id;
 
 static const char *mAssertion[] = {
-	"tdisp_query send_receive_data",
-	"sizeof(TdispMessage) == sizeof(TDISP_ERROR)",
-	"TdispMessage.TDISPVersion == 0x10",
-	"TdispMessage.MessageType == TDISP_ERROR",
-	"TdispMessage.INTERFACE_ID == START_INTERFACE_REQUEST.INTERFACE_ID",
-	"TdispMessage.ERROR_CODE == INVALID_INTERFACE_STATE",
-	"TdispMessage.TDI_STATE == CONFIG_UNLOCKED"
+	"tdisp_send_receive_data",
+	"sizeof(TdispMessage) = 0x%x",
+	"TdispMessage.TDISPVersion = 0x%x",
+	"TdispMessage.MessageType = 0x%x",
+	"TdispMessage.INTERFACE_ID = 0x%x",
+	"TdispMessage.ERROR_CODE = 0x%x",
+	"TdispMessage.TDI_STATE = 0x%x"
 };
 static pci_tdisp_lock_interface_response_t lock_interface_response = {0};
 static bool setup_success = false;
@@ -129,31 +129,37 @@ void tdisp_test_start_interface_3_run (void *test_context)
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 0, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[0]);
+	if (!res) {
+		return;
+	}
 
 	res = (response_size == sizeof (pci_tdisp_error_response_t));
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 1, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[1]);
+		assertion_result, mAssertion[1], response_size);
+	if(!res) {
+		return;
+	}
 
 	res = (response.header.version == PCI_TDISP_MESSAGE_VERSION_10);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 2, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[2]);
+		assertion_result, mAssertion[2], response.header.version);
 
 	res = (response.header.message_type == PCI_TDISP_ERROR);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 3, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[3]);
+		assertion_result, mAssertion[3], response.header.message_type);
 
 	res = (response.header.interface_id.function_id == g_tdisp_interface_id.function_id);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 4, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[4]);
+		assertion_result, mAssertion[4], response.header.interface_id.function_id);
 
 	res = (response.error_code == PCI_TDISP_ERROR_CODE_INVALID_INTERFACE_STATE);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[5]);
+		assertion_result, mAssertion[5], response.error_code);
 
 	pci_tdisp_device_interface_state_response_t get_state_response;
 
@@ -162,6 +168,8 @@ void tdisp_test_start_interface_3_run (void *test_context)
 		&response_size)) {
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_start_interface_3_run get_state failed.\n"));
+		teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
+			TEEIO_TEST_RESULT_FAILED, "tdisp_test_get_state failed.");
 
 		return;
 	}
@@ -169,7 +177,7 @@ void tdisp_test_start_interface_3_run (void *test_context)
 	res = (get_state_response.tdi_state == PCI_TDISP_INTERFACE_STATE_CONFIG_UNLOCKED);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[6]);
+		assertion_result, mAssertion[6], get_state_response.tdi_state);
 }
 
 void tdisp_test_start_interface_3_teardown (void *test_context)

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_start_interface_4.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_start_interface_4.c
@@ -13,13 +13,13 @@
 extern pci_tdisp_interface_id_t g_tdisp_interface_id;
 
 static const char *mAssertion[] = {
-	"tdisp_query send_receive_data",
-	"sizeof(TdispMessage) == sizeof(TDISP_ERROR)",
-	"TdispMessage.TDISPVersion == 0x10",
-	"TdispMessage.MessageType == TDISP_ERROR",
-	"TdispMessage.INTERFACE_ID == START_INTERFACE_REQUEST.INTERFACE_ID",
-	"TdispMessage.ERROR_CODE == INVALID_INTERFACE_STATE",
-	"TdispMessage.TDI_STATE == RUN"
+	"tdisp_send_receive_data",
+	"sizeof(TdispMessage) = 0x%x",
+	"TdispMessage.TDISPVersion = 0x%x",
+	"TdispMessage.MessageType = 0x%x",
+	"TdispMessage.INTERFACE_ID = 0x%x",
+	"TdispMessage.ERROR_CODE = 0x%x",
+	"TdispMessage.TDI_STATE = 0x%x"
 };
 static pci_tdisp_lock_interface_response_t lock_interface_response = {0};
 static bool setup_success = false;
@@ -129,31 +129,37 @@ void tdisp_test_start_interface_4_run (void *test_context)
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 0, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[0]);
+	if (!res) {
+		return;
+	}
 
 	res = (response_size == sizeof (pci_tdisp_error_response_t));
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 1, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[1]);
+		assertion_result, mAssertion[1], response_size);
+	if(!res) {
+		return;
+	}
 
 	res = (response.header.version == PCI_TDISP_MESSAGE_VERSION_10);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 2, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[2]);
+		assertion_result, mAssertion[2], response.header.version);
 
 	res = (response.header.message_type == PCI_TDISP_ERROR);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 3, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[3]);
+		assertion_result, mAssertion[3], response.header.message_type);
 
 	res = (response.header.interface_id.function_id == g_tdisp_interface_id.function_id);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 4, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[4]);
+		assertion_result, mAssertion[4], response.header.interface_id.function_id);
 
 	res = (response.error_code == PCI_TDISP_ERROR_CODE_INVALID_INTERFACE_STATE);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[5]);
+		assertion_result, mAssertion[5], response.error_code);
 
 	pci_tdisp_device_interface_state_response_t get_state_response;
 
@@ -162,6 +168,8 @@ void tdisp_test_start_interface_4_run (void *test_context)
 		&response_size)) {
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_start_interface_4_run get_state failed.\n"));
+		teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
+			TEEIO_TEST_RESULT_FAILED, "tdisp_test_get_state failed.");
 
 		return;
 	}
@@ -169,7 +177,7 @@ void tdisp_test_start_interface_4_run (void *test_context)
 	res = (get_state_response.tdi_state == PCI_TDISP_INTERFACE_STATE_RUN);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[6]);
+		assertion_result, mAssertion[6], get_state_response.tdi_state);
 }
 
 void tdisp_test_start_interface_4_teardown (void *test_context)

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_stop_interface_1.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_stop_interface_1.c
@@ -13,12 +13,12 @@
 extern pci_tdisp_interface_id_t g_tdisp_interface_id;
 
 static const char *mAssertion[] = {
-	"tdisp_query send_receive_data",
-	"sizeof(TdispMessage) == sizeof(STOP_INTERFACE_RESPONSE)",
-	"TdispMessage.TDISPVersion == 0x10",
-	"TdispMessage.MessageType == STOP_INTERFACE_RESPONSE",
-	"TdispMessage.INTERFACE_ID == STOP_INTERFACE_REQUEST.INTERFACE_ID",
-	"TdispMessage.TDI_STATE == CONFIG_UNLOCKED"
+	"tdisp_send_receive_data",
+	"sizeof(TdispMessage) = 0x%x",
+	"TdispMessage.TDISPVersion = 0x%x",
+	"TdispMessage.MessageType = 0x%x",
+	"TdispMessage.INTERFACE_ID = 0x%x",
+	"TdispMessage.TDI_STATE = 0x%x",
 };
 static pci_tdisp_responder_capabilities_t rsp_caps = {0};
 static bool setup_success = false;
@@ -133,26 +133,32 @@ void tdisp_test_stop_interface_1_run (void *test_context)
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 0, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[0]);
+	if (!res) {
+		return;
+	}
 
 	res = (response_size == sizeof (pci_tdisp_stop_interface_response_t));
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 1, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[1]);
+		assertion_result, mAssertion[1], response_size);
+	if (!res) {
+		return;
+	}
 
 	res = (response.header.version == PCI_TDISP_MESSAGE_VERSION_10);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 2, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[2]);
+		assertion_result, mAssertion[2], response.header.version);
 
 	res = (response.header.message_type == PCI_TDISP_STOP_INTERFACE_RSP);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 3, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[3]);
+		assertion_result, mAssertion[3], response.header.message_type);
 
 	res = (response.header.interface_id.function_id == g_tdisp_interface_id.function_id);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 4, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[4]);
+		assertion_result, mAssertion[4], response.header.interface_id.function_id);
 
 	pci_tdisp_device_interface_state_response_t get_state_response;
 
@@ -161,6 +167,8 @@ void tdisp_test_stop_interface_1_run (void *test_context)
 		&response_size)) {
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_stop_interface_1_run get_state failed.\n"));
+		teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
+			TEEIO_TEST_RESULT_FAILED, "tdisp_test_get_state failed.");
 
 		return;
 	}
@@ -169,7 +177,7 @@ void tdisp_test_stop_interface_1_run (void *test_context)
 		PCI_TDISP_INTERFACE_STATE_CONFIG_UNLOCKED);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[5]);
+		assertion_result, mAssertion[5], get_state_response.tdi_state);
 }
 
 void tdisp_test_stop_interface_1_teardown (void *test_context)

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_stop_interface_2.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_stop_interface_2.c
@@ -13,12 +13,12 @@
 extern pci_tdisp_interface_id_t g_tdisp_interface_id;
 
 static const char *mAssertion[] = {
-	"tdisp_query send_receive_data",
-	"sizeof(TdispMessage) == sizeof(STOP_INTERFACE_RESPONSE)",
-	"TdispMessage.TDISPVersion == 0x10",
-	"TdispMessage.MessageType == STOP_INTERFACE_RESPONSE",
-	"TdispMessage.INTERFACE_ID == STOP_INTERFACE_REQUEST.INTERFACE_ID",
-	"TdispMessage.TDI_STATE == CONFIG_UNLOCKED"
+	"tdisp_send_receive_data",
+	"sizeof(TdispMessage) = 0x%x",
+	"TdispMessage.TDISPVersion = 0x%x",
+	"TdispMessage.MessageType = 0x%x",
+	"TdispMessage.INTERFACE_ID = 0x%x",
+	"TdispMessage.TDI_STATE = 0x%x"
 };
 static pci_tdisp_responder_capabilities_t rsp_caps = {0};
 static bool setup_success = false;
@@ -121,26 +121,32 @@ void tdisp_test_stop_interface_2_run (void *test_context)
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 0, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[0]);
+	if (!res) {
+		return;
+	}
 
 	res = (response_size == sizeof (pci_tdisp_stop_interface_response_t));
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 1, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[1]);
+		assertion_result, mAssertion[1], response_size);
+	if(!res) {
+		return;
+	}
 
 	res = (response.header.version == PCI_TDISP_MESSAGE_VERSION_10);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 2, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[2]);
+		assertion_result, mAssertion[2], response.header.version);
 
 	res = (response.header.message_type == PCI_TDISP_STOP_INTERFACE_RSP);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 3, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[3]);
+		assertion_result, mAssertion[3], response.header.message_type);
 
 	res = (response.header.interface_id.function_id == g_tdisp_interface_id.function_id);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 4, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[4]);
+		assertion_result, mAssertion[4], response.header.interface_id.function_id);
 
 	pci_tdisp_device_interface_state_response_t get_state_response;
 
@@ -149,6 +155,8 @@ void tdisp_test_stop_interface_2_run (void *test_context)
 		&response_size)) {
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_stop_interface_2_run get_state failed.\n"));
+		teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
+			TEEIO_TEST_RESULT_FAILED, "tdisp_test_get_state failed.");
 
 		return;
 	}
@@ -157,7 +165,7 @@ void tdisp_test_stop_interface_2_run (void *test_context)
 		PCI_TDISP_INTERFACE_STATE_CONFIG_UNLOCKED);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[5]);
+		assertion_result, mAssertion[5], get_state_response.tdi_state);
 }
 
 void tdisp_test_stop_interface_2_teardown (void *test_context)

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_stop_interface_3.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_stop_interface_3.c
@@ -13,12 +13,12 @@
 extern pci_tdisp_interface_id_t g_tdisp_interface_id;
 
 static const char *mAssertion[] = {
-	"tdisp_query send_receive_data",
-	"sizeof(TdispMessage) == sizeof(STOP_INTERFACE_RESPONSE)",
-	"TdispMessage.TDISPVersion == 0x10",
-	"TdispMessage.MessageType == STOP_INTERFACE_RESPONSE",
-	"TdispMessage.INTERFACE_ID == STOP_INTERFACE_REQUEST.INTERFACE_ID",
-	"TdispMessage.TDI_STATE == CONFIG_UNLOCKED"
+	"tdisp_send_receive_data",
+	"sizeof(TdispMessage) = 0x%x",
+	"TdispMessage.TDISPVersion = 0x%x",
+	"TdispMessage.MessageType = 0x%x",
+	"TdispMessage.INTERFACE_ID = 0x%x",
+	"TdispMessage.TDI_STATE = 0x%x",
 };
 static bool setup_success = false;
 
@@ -105,26 +105,32 @@ void tdisp_test_stop_interface_3_run (void *test_context)
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 0, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[0]);
+	if (!res) {
+		return;
+	}
 
 	res = (response_size == sizeof (pci_tdisp_stop_interface_response_t));
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 1, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[1]);
+		assertion_result, mAssertion[1], response_size);
+	if (!res) {
+		return;
+	}
 
 	res = (response.header.version == PCI_TDISP_MESSAGE_VERSION_10);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 2, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[2]);
+		assertion_result, mAssertion[2], response.header.version);
 
 	res = (response.header.message_type == PCI_TDISP_STOP_INTERFACE_RSP);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 3, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[3]);
+		assertion_result, mAssertion[3], response.header.message_type);
 
 	res = (response.header.interface_id.function_id == g_tdisp_interface_id.function_id);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 4, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[4]);
+		assertion_result, mAssertion[4], response.header.interface_id.function_id);
 
 	pci_tdisp_device_interface_state_response_t get_state_response;
 
@@ -133,6 +139,8 @@ void tdisp_test_stop_interface_3_run (void *test_context)
 		&response_size)) {
 		TEEIO_DEBUG ((TEEIO_DEBUG_ERROR,
 			"tdisp_test_stop_interface_2_run get_state failed.\n"));
+		teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
+			TEEIO_TEST_RESULT_FAILED, "tdisp_test_get_state failed.");
 
 		return;
 	}
@@ -141,7 +149,7 @@ void tdisp_test_stop_interface_3_run (void *test_context)
 		PCI_TDISP_INTERFACE_STATE_CONFIG_UNLOCKED);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[5]);
+		assertion_result, mAssertion[5], get_state_response.tdi_state);
 }
 
 void tdisp_test_stop_interface_3_teardown (void *test_context)

--- a/teeio-validator/library/tdisp_test_lib/test_case/test_case_version_1.c
+++ b/teeio-validator/library/tdisp_test_lib/test_case/test_case_version_1.c
@@ -12,13 +12,13 @@
 extern pci_tdisp_interface_id_t g_tdisp_interface_id;
 
 static const char *mAssertion[] = {
-	"tdisp_version send_receive_data",
-	"sizeof(TdispMessage) == sizeof(TDISP_VERSION)",
-	"TdispMessage.TDISPVersion == 0x10",
-	"TdispMessage.MessageType == TDISP_VERSION",
-	"TdispMessage.INTERFACE_ID == GET_TDISP_VERSION.INTERFACE_ID",
-	"TdispMessage.VERSION_NUM_COUNT == 1",
-	"TdispMessage.VERSION_NUM_ENTRY[0] == 0x10"
+	"tdisp_send_receive_data",
+	"sizeof(TdispMessage) = 0x%x",
+	"TdispMessage.TDISPVersion = 0x%x",
+	"TdispMessage.MessageType = 0x%x",
+	"TdispMessage.INTERFACE_ID = 0x%x",
+	"TdispMessage.VERSION_NUM_COUNT = 0x%x",
+	"TdispMessage.VERSION_NUM_ENTRY[0] = 0x%x"
 };
 
 
@@ -52,36 +52,42 @@ void tdisp_test_version_1_run (void *test_context)
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 0, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
 		assertion_result, mAssertion[0]);
+	if(!res) {
+		return;
+	}
 
 	res = (response_size == sizeof (pci_tdisp_version_response_mine_t));
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 1, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[1]);
+		assertion_result, mAssertion[1], response_size);
+	if(!res) {
+		return;
+	}
 
 	res = (response.header.version == PCI_TDISP_MESSAGE_VERSION_10);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 2, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[2]);
+		assertion_result, mAssertion[2], response.header.version);
 
 	res = (response.header.message_type == PCI_TDISP_VERSION);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 3, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[3]);
+		assertion_result, mAssertion[3], response.header.message_type);
 
 	res = (response.header.interface_id.function_id == g_tdisp_interface_id.function_id);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 4, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[4]);
+		assertion_result, mAssertion[4], response.header.interface_id.function_id);
 
 	res = (response.version_num_count == 1);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 5, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[5]);
+		assertion_result, mAssertion[5], response.version_num_count);
 
 	res = (response.version_num_entry[0] == PCI_TDISP_MESSAGE_VERSION_10);
 	assertion_result = res ? TEEIO_TEST_RESULT_PASS : TEEIO_TEST_RESULT_FAILED;
 	teeio_record_assertion_result (case_class, case_id, 6, IDE_COMMON_TEST_CASE_ASSERTION_TYPE_TEST,
-		assertion_result, mAssertion[6]);
+		assertion_result, mAssertion[6], response.version_num_entry[0]);
 }
 
 void tdisp_test_version_1_teardown (void *test_context)


### PR DESCRIPTION
Fix #302 