### PR TITLE
Support non-zero port_index values in PCIE IDE Test.IdeStream/KeyRefresh

### DIFF
--- a/teeio-validator/include/ide_test.h
+++ b/teeio-validator/include/ide_test.h
@@ -138,6 +138,7 @@ typedef struct
   uint8_t bus;
   uint8_t device;
   uint8_t function;
+  uint8_t port_index;
 } IDE_PORT;
 
 typedef struct

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_full.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_full.c
@@ -40,8 +40,8 @@ bool pcie_ide_test_full_1_setup(void *test_context)
   return setup_ide_stream(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id, PCI_IDE_KM_KEY_SET_K0,
                           &group_context->k_set, group_context->rp_stream_index,
-                          0, group_context->common.top->type, upper_port, lower_port, false);
-
+                          group_context->common.lower_port.port->port_index,
+                          group_context->common.top->type, upper_port, lower_port, false);
 }
 
 void pcie_ide_test_full_1_run(void *test_context)
@@ -198,7 +198,7 @@ bool pcie_ide_teardown_common(void *test_context, uint8_t ks)
   void* spdm_context = group_context->spdm_doe.spdm_context;
   uint32_t session_id = group_context->spdm_doe.session_id;
   uint8_t stream_id = group_context->stream_id;
-  uint8_t port_index = 0;
+  uint8_t port_index = group_context->common.lower_port.port->port_index;
   bool res = false;
 
   // then test KSetStop  

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_full_keyrefresh.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_full_keyrefresh.c
@@ -46,7 +46,8 @@ bool pcie_ide_test_full_keyrefresh_setup(void *test_context)
   return setup_ide_stream(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id, mKeySet,
                           &group_context->k_set, group_context->rp_stream_index,
-                          0, group_context->common.top->type, upper_port, lower_port, false);
+                          group_context->common.lower_port.port->port_index,
+                          group_context->common.top->type, upper_port, lower_port, false);
 }
 
 void pcie_ide_test_full_keyrefresh_run(void *test_context)
@@ -126,7 +127,8 @@ void pcie_ide_test_full_keyrefresh_run(void *test_context)
       res = ide_key_switch_to(doe_context, spdm_context, &session_id,
                               upper_port->mapped_kcbar_addr, stream_id,
                               &group_context->k_set, group_context->rp_stream_index,
-                              0, group_context->common.top->type, upper_port, lower_port, ks, false);
+                              group_context->common.lower_port.port->port_index,
+                              group_context->common.top->type, upper_port, lower_port, ks, false);
       if(!res) {
         break;
       } else {


### PR DESCRIPTION
Fix #309
In the test group setup, use IDE KM Query to retrieve the port_index that corresponds to the port BDF.