### PR TITLE
Support non-zero port_index values in PCIE IDE test cases.

### DIFF
--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_1.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_1.c
@@ -180,6 +180,7 @@ void pcie_ide_test_keyprog_1_run(void *test_context)
   uint8_t ks;
   uint8_t direction;
   uint8_t substream;
+  uint8_t port_index = group_context->common.lower_port.port->port_index;
 
   iv.bytes[0] = PCIE_IDE_IV_INIT_VALUE;
 
@@ -201,7 +202,7 @@ void pcie_ide_test_keyprog_1_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|PR\n"));
   test_ide_km_key_prog_case1(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, "K0|RX|PR", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, "K0|RX|PR", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // program key in root port kcbar registers
@@ -219,7 +220,7 @@ void pcie_ide_test_keyprog_1_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|NPR\n"));
   test_ide_km_key_prog_case1(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, "K0|RX|NPR", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, "K0|RX|NPR", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // program key in root port kcbar registers
@@ -237,7 +238,7 @@ void pcie_ide_test_keyprog_1_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|CPL\n"));
   test_ide_km_key_prog_case1(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, "K0|RX|CPL", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, "K0|RX|CPL", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // program key in root port kcbar registers
@@ -262,7 +263,7 @@ void pcie_ide_test_keyprog_1_run(void *test_context)
 
   test_ide_km_key_prog_case1(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, "K0|TX|PR", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, "K0|TX|PR", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // program key in root port kcbar registers
@@ -280,7 +281,7 @@ void pcie_ide_test_keyprog_1_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|NPR\n"));
   test_ide_km_key_prog_case1(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, "K0|TX|NPR", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, "K0|TX|NPR", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // program key in root port kcbar registers
@@ -298,7 +299,7 @@ void pcie_ide_test_keyprog_1_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|CPL\n"));
   test_ide_km_key_prog_case1(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, "K0|TX|CPL", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, "K0|TX|CPL", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // program key in root port kcbar registers

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_2.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_2.c
@@ -128,6 +128,7 @@ void pcie_ide_test_keyprog_2_run(void *test_context)
   uint8_t ks;
   uint8_t direction;
   uint8_t substream;
+  uint8_t port_index = group_context->common.lower_port.port->port_index;
   int request_size = 0;
 
   uint8_t k_sets[] = {PCI_IDE_KM_KEY_SET_K0, PCI_IDE_KM_KEY_SET_K1};
@@ -149,7 +150,7 @@ void pcie_ide_test_keyprog_2_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|PR with request_size=%d\n", request_size));
   test_ide_km_key_prog_case2(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, request_size, "K0|RX|PR", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, request_size, "K0|RX|PR", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|RX|NPR
@@ -162,7 +163,7 @@ void pcie_ide_test_keyprog_2_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|NPR with request_size=%d\n", request_size));
   test_ide_km_key_prog_case2(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, request_size, "K0|RX|NPR", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, request_size, "K0|RX|NPR", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|RX|CPL
@@ -175,7 +176,7 @@ void pcie_ide_test_keyprog_2_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|CPL with request_size=%d\n", request_size));
   test_ide_km_key_prog_case2(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, request_size, "K0|RX|CPL", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, request_size, "K0|RX|CPL", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|TX|PR
@@ -188,7 +189,7 @@ void pcie_ide_test_keyprog_2_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|PR with request_size=%d\n", request_size));
   test_ide_km_key_prog_case2(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, request_size, "K0|TX|PR", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, request_size, "K0|TX|PR", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|TX|NPR
@@ -201,7 +202,7 @@ void pcie_ide_test_keyprog_2_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|NPR with request_size=%d\n", request_size));
   test_ide_km_key_prog_case2(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, request_size, "K0|TX|NPR", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, request_size, "K0|TX|NPR", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|TX|CPL
@@ -214,7 +215,7 @@ void pcie_ide_test_keyprog_2_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|CPL with request_size=%d\n", request_size));
   test_ide_km_key_prog_case2(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, request_size, "K0|TX|CPL", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, request_size, "K0|TX|CPL", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 }
 

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_4.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_4.c
@@ -130,6 +130,7 @@ void pcie_ide_test_keyprog_4_run(void *test_context)
   uint8_t ks;
   uint8_t direction;
   uint8_t substream;
+  uint8_t port_index = group_context->common.lower_port.port->port_index;
 
   uint8_t k_sets[] = {PCI_IDE_KM_KEY_SET_K0, PCI_IDE_KM_KEY_SET_K1};
   uint8_t directions[] = {PCI_IDE_KM_KEY_DIRECTION_RX, PCI_IDE_KM_KEY_DIRECTION_TX};
@@ -149,7 +150,7 @@ void pcie_ide_test_keyprog_4_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|PR with substream=%d\n", substreams[substream]>>4));
   test_ide_km_key_prog_case4(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, "K0|RX|PR", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, "K0|RX|PR", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|RX|NPR
@@ -161,7 +162,7 @@ void pcie_ide_test_keyprog_4_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|NPR with substream=%d\n", substreams[substream]>>4));
   test_ide_km_key_prog_case4(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, "K0|RX|NPR", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, "K0|RX|NPR", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|RX|CPL
@@ -173,7 +174,7 @@ void pcie_ide_test_keyprog_4_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|CPL with substream=%d\n", substreams[substream]>>4));
   test_ide_km_key_prog_case4(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, "K0|RX|CPL", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, "K0|RX|CPL", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|TX|PR
@@ -185,7 +186,7 @@ void pcie_ide_test_keyprog_4_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|PR with substream=%d\n", substreams[substream]>>4));
   test_ide_km_key_prog_case4(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, "K0|TX|PR", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, "K0|TX|PR", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|TX|NPR
@@ -197,7 +198,7 @@ void pcie_ide_test_keyprog_4_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|NPR with substream=%d\n", substreams[substream]>>4));
   test_ide_km_key_prog_case4(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, "K0|TX|NPR", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, "K0|TX|NPR", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|TX|CPL
@@ -209,7 +210,7 @@ void pcie_ide_test_keyprog_4_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|CPL with substream=%d\n", substreams[substream]>>4));
   test_ide_km_key_prog_case4(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, "K0|TX|CPL", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, "K0|TX|CPL", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 }
 

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_5.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_5.c
@@ -131,6 +131,7 @@ void pcie_ide_test_keyprog_5_run(void *test_context)
   uint8_t ks;
   uint8_t direction;
   uint8_t substream;
+  uint8_t port_index = group_context->common.lower_port.port->port_index;
 
   uint8_t k_sets[] = {PCI_IDE_KM_KEY_SET_K0, PCI_IDE_KM_KEY_SET_K1};
   uint8_t directions[] = {PCI_IDE_KM_KEY_DIRECTION_RX, PCI_IDE_KM_KEY_DIRECTION_TX};
@@ -151,7 +152,7 @@ void pcie_ide_test_keyprog_5_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|PR with iv=%d\n", key_buffer.iv[1]));
   test_ide_km_key_prog_case5(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, "K0|RX|PR", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, "K0|RX|PR", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|RX|NPR
@@ -164,7 +165,7 @@ void pcie_ide_test_keyprog_5_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|NPR with iv=%d\n", key_buffer.iv[1]));
   test_ide_km_key_prog_case5(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, "K0|RX|NPR", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, "K0|RX|NPR", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|RX|CPL
@@ -177,7 +178,7 @@ void pcie_ide_test_keyprog_5_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|CPL with iv=%d\n", key_buffer.iv[1]));
   test_ide_km_key_prog_case5(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, "K0|RX|CPL", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, "K0|RX|CPL", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|TX|PR
@@ -190,7 +191,7 @@ void pcie_ide_test_keyprog_5_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|PR with iv=%d\n", key_buffer.iv[1]));
   test_ide_km_key_prog_case5(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, "K0|TX|PR", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, "K0|TX|PR", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|TX|NPR
@@ -203,7 +204,7 @@ void pcie_ide_test_keyprog_5_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|NPR with iv=%d\n", key_buffer.iv[1]));
   test_ide_km_key_prog_case5(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, "K0|TX|NPR", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, "K0|TX|NPR", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|TX|CPL
@@ -216,7 +217,7 @@ void pcie_ide_test_keyprog_5_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|CPL with iv=%d\n", key_buffer.iv[1]));
   test_ide_km_key_prog_case5(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, "K0|TX|CPL", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, "K0|TX|CPL", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 }
 

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_6.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_keyprog_6.c
@@ -130,6 +130,7 @@ void pcie_ide_test_keyprog_6_run(void *test_context)
   uint8_t ks;
   uint8_t direction;
   uint8_t substream;
+  uint8_t port_index = group_context->common.lower_port.port->port_index;
 
   uint8_t k_sets[] = {PCI_IDE_KM_KEY_SET_K0, PCI_IDE_KM_KEY_SET_K1};
   uint8_t directions[] = {PCI_IDE_KM_KEY_DIRECTION_RX, PCI_IDE_KM_KEY_DIRECTION_TX};
@@ -150,7 +151,7 @@ void pcie_ide_test_keyprog_6_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|PR with stream_id=%d\n", stream_id));
   test_ide_km_key_prog_case6(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, "K0|RX|PR", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, "K0|RX|PR", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|RX|NPR
@@ -163,7 +164,7 @@ void pcie_ide_test_keyprog_6_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|NPR with stream_id=%d\n", stream_id));
   test_ide_km_key_prog_case6(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, "K0|RX|NPR", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, "K0|RX|NPR", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|RX|CPL
@@ -176,7 +177,7 @@ void pcie_ide_test_keyprog_6_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|RX|CPL with stream_id=%d\n", stream_id));
   test_ide_km_key_prog_case6(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, "K0|RX|CPL", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, "K0|RX|CPL", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|TX|PR
@@ -189,7 +190,7 @@ void pcie_ide_test_keyprog_6_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|PR with stream_id=%d\n", stream_id));
   test_ide_km_key_prog_case6(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, "K0|TX|PR", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, "K0|TX|PR", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|TX|NPR
@@ -202,7 +203,7 @@ void pcie_ide_test_keyprog_6_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|NPR with stream_id=%d\n", stream_id));
   test_ide_km_key_prog_case6(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, "K0|TX|NPR", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, "K0|TX|NPR", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 
   // KS0|TX|CPL
@@ -215,7 +216,7 @@ void pcie_ide_test_keyprog_6_run(void *test_context)
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KeyProg K0|TX|CPL stream_id=%d\n", stream_id));
   test_ide_km_key_prog_case6(doe_context, spdm_context, &session_id, stream_id,
                                 k_sets[ks] | directions[direction] | substreams[substream],
-                                0, &key_buffer, &kp_ack_status, "K0|TX|CPL", case_class, case_id);
+                                port_index, &key_buffer, &kp_ack_status, "K0|TX|CPL", case_class, case_id);
   dump_key_iv_in_key_prog(key_buffer.key, sizeof(key_buffer.key)/sizeof(uint32_t), key_buffer.iv, sizeof(key_buffer.iv)/sizeof(uint32_t));
 }
 

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_1.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_1.c
@@ -216,7 +216,7 @@ bool pcie_ide_test_ksetgo_1_setup(void *test_context)
 
   return test_ksetgo_setup_common(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
     group_context->common.upper_port.mapped_kcbar_addr, group_context->stream_id, group_context->rp_stream_index,
-    group_context->common.upper_port.ide_id, &group_context->k_set, 0, PCIE_IDE_STREAM_KS0);
+    group_context->common.upper_port.ide_id, &group_context->k_set, group_context->common.lower_port.port->port_index, PCIE_IDE_STREAM_KS0);
 }
 
 void pcie_ide_test_ksetgo_1_run(void *test_context)
@@ -238,20 +238,21 @@ void pcie_ide_test_ksetgo_1_run(void *test_context)
   void *doe_context = group_context->spdm_doe.doe_context;
   void *spdm_context = group_context->spdm_doe.spdm_context;
   uint32_t session_id = group_context->spdm_doe.session_id;
+  uint8_t port_index = group_context->common.lower_port.port->port_index;
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetGo K0|RX|PR\n"));
   test_ide_km_key_set_go(doe_context, spdm_context, &session_id, stream_id,
-                             PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_PR, 0,
+                             PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_PR, port_index,
                              true, "K0|RX|PR", case_class, case_id);
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetGo K0|RX|NPR\n"));
   test_ide_km_key_set_go(doe_context, spdm_context, &session_id, stream_id,
-                              PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_NPR, 0,
+                              PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_NPR, port_index,
                               true, "K0|RX|NPR", case_class, case_id);
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetGo K0|RX|CPL\n"));
   test_ide_km_key_set_go(doe_context, spdm_context, &session_id, stream_id,
-                              PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_CPL, 0,
+                              PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_CPL, port_index,
                               true, "K0|RX|CPL", case_class, case_id);
 
   // set key_set_select in host ide
@@ -262,17 +263,17 @@ void pcie_ide_test_ksetgo_1_run(void *test_context)
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetGo K0|TX|PR\n"));
   test_ide_km_key_set_go(doe_context, spdm_context, &session_id, stream_id,
-                             PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_PR, 0,
+                             PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_PR, port_index,
                              true, "K0|TX|PR", case_class, case_id);
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetGo K0|TX|NPR\n"));
   test_ide_km_key_set_go(doe_context, spdm_context, &session_id, stream_id,
-                              PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_NPR, 0,
+                              PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_NPR, port_index,
                               true, "K0|TX|NPR", case_class, case_id);
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetGo K0|TX|CPL\n"));
   test_ide_km_key_set_go(doe_context, spdm_context, &session_id, stream_id,
-                              PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_CPL, 0,
+                              PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_CPL, port_index,
                               true, "K0|TX|CPL", case_class, case_id);
 
   if(teeio_test_case_result(case_class, case_id) != TEEIO_TEST_RESULT_PASS) {

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_2.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_2.c
@@ -39,7 +39,7 @@ bool pcie_ide_test_ksetgo_2_setup(void *test_context)
 
   return test_ksetgo_setup_common(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
     group_context->common.upper_port.mapped_kcbar_addr, group_context->stream_id, group_context->rp_stream_index,
-    group_context->common.upper_port.ide_id, &group_context->k_set, 0, PCIE_IDE_STREAM_KS1);
+    group_context->common.upper_port.ide_id, &group_context->k_set, group_context->common.lower_port.port->port_index, PCIE_IDE_STREAM_KS1);
 }
 
 void pcie_ide_test_ksetgo_2_run(void *test_context)
@@ -61,20 +61,21 @@ void pcie_ide_test_ksetgo_2_run(void *test_context)
   void *doe_context = group_context->spdm_doe.doe_context;
   void *spdm_context = group_context->spdm_doe.spdm_context;
   uint32_t session_id = group_context->spdm_doe.session_id;
+  uint8_t port_index = group_context->common.lower_port.port->port_index;
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetGo K1|RX|PR\n"));
   test_ide_km_key_set_go(doe_context, spdm_context, &session_id, stream_id,
-                             PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_PR, 0,
+                             PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_PR, port_index,
                              true, "K1|RX|PR", case_class, case_id);
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetGo K1|RX|NPR\n"));
   test_ide_km_key_set_go(doe_context, spdm_context, &session_id, stream_id,
-                              PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_NPR, 0,
+                              PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_NPR, port_index,
                               true, "K1|RX|NPR", case_class, case_id);
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetGo K1|RX|CPL\n"));
   test_ide_km_key_set_go(doe_context, spdm_context, &session_id, stream_id,
-                              PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_CPL, 0,
+                              PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_CPL, port_index,
                               true, "K1|RX|CPL", case_class, case_id);
 
   // set key_set_select in host ide
@@ -85,17 +86,17 @@ void pcie_ide_test_ksetgo_2_run(void *test_context)
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetGo K1|TX|PR\n"));
   test_ide_km_key_set_go(doe_context, spdm_context, &session_id, stream_id,
-                             PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_PR, 0,
+                             PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_PR, port_index,
                              true, "K1|TX|PR", case_class, case_id);
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetGo K1|TX|NPR\n"));
   test_ide_km_key_set_go(doe_context, spdm_context, &session_id, stream_id,
-                              PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_NPR, 0,
+                              PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_NPR, port_index,
                               true, "K1|TX|NPR", case_class, case_id);
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetGo K1|TX|CPL\n"));
   test_ide_km_key_set_go(doe_context, spdm_context, &session_id, stream_id,
-                              PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_CPL, 0,
+                              PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_CPL, port_index,
                               true, "K1|TX|CPL", case_class, case_id);
 
   if(teeio_test_case_result(case_class, case_id) != TEEIO_TEST_RESULT_PASS) {

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_3.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_3.c
@@ -46,7 +46,7 @@ bool pcie_ide_test_ksetgo_3_setup(void *test_context)
   bool res = setup_ide_stream(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id, PCI_IDE_KM_KEY_SET_K0,
                           &group_context->k_set, group_context->rp_stream_index,
-                          0, group_context->common.top->type,
+                          group_context->common.lower_port.port->port_index, group_context->common.top->type,
                           upper_port, lower_port, true);
   if(!res) {
     return false;
@@ -57,7 +57,8 @@ bool pcie_ide_test_ksetgo_3_setup(void *test_context)
 
 bool test_ksetgo_3_run_phase1(void* doe_context, void* spdm_context, uint32_t* session_id,
                               uint8_t stream_id, uint8_t rp_stream_index,
-                              uint8_t* kcbar_addr, IDE_TEST_TOPOLOGY_TYPE top_type,
+                              uint8_t* kcbar_addr, uint8_t port_index,
+                              IDE_TEST_TOPOLOGY_TYPE top_type,
                               ide_common_test_port_context_t* upper_port,
                               ide_common_test_port_context_t* lower_port,
                               int case_class, int case_id)
@@ -65,17 +66,17 @@ bool test_ksetgo_3_run_phase1(void* doe_context, void* spdm_context, uint32_t* s
   // Now KSetGo
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "KSetGo %s|RX|PR\n", k_set_names[PCI_IDE_KM_KEY_SET_K0]));
   test_ide_km_key_set_go(doe_context, spdm_context, session_id, stream_id,
-                             PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_PR, 0, true,
+                             PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_PR, port_index, true,
                              "K0|RX|PR", case_class, case_id);
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "KSetGo %s|RX|NPR\n", k_set_names[PCI_IDE_KM_KEY_SET_K0]));
   test_ide_km_key_set_go(doe_context, spdm_context, session_id, stream_id,
-                             PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_NPR, 0, true,
+                             PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_NPR, port_index, true,
                              "K0|RX|NPR", case_class, case_id);
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "KSetGo %s|RX|CPL\n", k_set_names[PCI_IDE_KM_KEY_SET_K0]));
   test_ide_km_key_set_go(doe_context, spdm_context, session_id, stream_id,
-                             PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_CPL, 0, true,
+                             PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_CPL, port_index, true,
                              "K0|RX|CPL", case_class, case_id);
 
   // set key_set_select in host ide
@@ -86,17 +87,17 @@ bool test_ksetgo_3_run_phase1(void* doe_context, void* spdm_context, uint32_t* s
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "KSetGo %s|TX|PR\n", k_set_names[PCI_IDE_KM_KEY_SET_K0]));
   test_ide_km_key_set_go(doe_context, spdm_context, session_id, stream_id,
-                             PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_PR, 0, true,
+                             PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_PR, port_index, true,
                              "K0|TX|PR", case_class, case_id);
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "KSetGo %s|TX|NPR\n", k_set_names[PCI_IDE_KM_KEY_SET_K0]));
   test_ide_km_key_set_go(doe_context, spdm_context, session_id, stream_id,
-                             PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_NPR, 0, true,
+                             PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_NPR, port_index, true,
                              "K0|TX|NPR", case_class, case_id);
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "KSetGo %s|TX|CPL\n", k_set_names[PCI_IDE_KM_KEY_SET_K0]));
   test_ide_km_key_set_go(doe_context, spdm_context, session_id, stream_id,
-                             PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_CPL, 0, true,
+                             PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_CPL, port_index, true,
                              "K0|TX|CPL", case_class, case_id);
 
   if(teeio_test_case_result(case_class, case_id) != TEEIO_TEST_RESULT_PASS) {
@@ -139,22 +140,23 @@ bool test_ksetgo_3_run_phase1(void* doe_context, void* spdm_context, uint32_t* s
 
 bool test_ksetgo_3_run_phase2(void* doe_context, void* spdm_context, uint32_t* session_id,
                               uint8_t stream_id, uint8_t rp_stream_index, uint8_t ide_id,
-                              uint8_t* kcbar_addr, IDE_TEST_TOPOLOGY_TYPE top_type,
+                              uint8_t* kcbar_addr, uint8_t port_index,
+                              IDE_TEST_TOPOLOGY_TYPE top_type,
                               int case_class, int case_id)
 {
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetGo K1|RX|PR\n"));
   test_ide_km_key_set_go(doe_context, spdm_context, session_id, stream_id,
-                             PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_PR, 0,
+                             PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_PR, port_index,
                              false, "K1|RX|PR", case_class, case_id);
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetGo K1|RX|NPR\n"));
   test_ide_km_key_set_go(doe_context, spdm_context, session_id, stream_id,
-                              PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_NPR, 0,
+                              PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_NPR, port_index,
                               false, "K1|RX|NPR", case_class, case_id);
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetGo K1|RX|CPL\n"));
   test_ide_km_key_set_go(doe_context, spdm_context, session_id, stream_id,
-                             PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_CPL, 0,
+                             PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_CPL, port_index,
                              false, "K1|RX|CPL", case_class, case_id);
 
   // set key_set_select in host ide
@@ -165,17 +167,17 @@ bool test_ksetgo_3_run_phase2(void* doe_context, void* spdm_context, uint32_t* s
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetGo K1|TX|PR\n"));
   test_ide_km_key_set_go(doe_context, spdm_context, session_id, stream_id,
-                             PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_PR, 0,
+                             PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_PR, port_index,
                              false, "K1|TX|PR", case_class, case_id);
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetGo K1|TX|NPR\n"));
   test_ide_km_key_set_go(doe_context, spdm_context, session_id, stream_id,
-                              PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_NPR, 0,
+                              PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_NPR, port_index,
                               false, "K1|TX|NPR", case_class, case_id);
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetGo K1|TX|CPL\n"));
   test_ide_km_key_set_go(doe_context, spdm_context, session_id, stream_id,
-                              PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_CPL, 0,
+                              PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_CPL, port_index,
                               false, "K1|TX|CPL", case_class, case_id);
 
   if(teeio_test_case_result(case_class, case_id) == TEEIO_TEST_RESULT_PASS) {
@@ -207,6 +209,7 @@ void pcie_ide_test_ksetgo_3_run(void *test_context)
   void *doe_context = group_context->spdm_doe.doe_context;
   void *spdm_context = group_context->spdm_doe.spdm_context;
   uint32_t session_id = group_context->spdm_doe.session_id;
+  uint8_t port_index = group_context->common.lower_port.port->port_index;
 
   ide_common_test_port_context_t* upper_port = &group_context->common.upper_port;
   ide_common_test_port_context_t* lower_port = &group_context->common.lower_port;
@@ -214,7 +217,8 @@ void pcie_ide_test_ksetgo_3_run(void *test_context)
   // phase 1
   res = test_ksetgo_3_run_phase1(doe_context, spdm_context, &session_id,
                                 stream_id, group_context->rp_stream_index,
-                                upper_port->mapped_kcbar_addr, group_context->common.top->type,
+                                upper_port->mapped_kcbar_addr, port_index,
+                                group_context->common.top->type,
                                 upper_port, lower_port,
                                 case_class, case_id);
   if(!res) {
@@ -225,7 +229,7 @@ void pcie_ide_test_ksetgo_3_run(void *test_context)
   res = ide_key_switch_to(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id,
                           &group_context->k_set, group_context->rp_stream_index,
-                          0, group_context->common.top->type, upper_port, lower_port, PCIE_IDE_STREAM_KS1, true);
+                          port_index, group_context->common.top->type, upper_port, lower_port, PCIE_IDE_STREAM_KS1, true);
   if(!res) {
     goto Done;
   }
@@ -233,7 +237,8 @@ void pcie_ide_test_ksetgo_3_run(void *test_context)
   // phase 2
   res = test_ksetgo_3_run_phase2(doe_context, spdm_context, &session_id,
                                 stream_id, group_context->rp_stream_index, upper_port->ide_id,
-                                upper_port->mapped_kcbar_addr, group_context->common.top->type,
+                                upper_port->mapped_kcbar_addr, port_index,
+                                group_context->common.top->type,
                                 case_class, case_id);
 
 Done:

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_4.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetgo_4.c
@@ -46,7 +46,8 @@ bool pcie_ide_test_ksetgo_4_setup(void *test_context)
   bool res = setup_ide_stream(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id, PCI_IDE_KM_KEY_SET_K1,
                           &group_context->k_set, group_context->rp_stream_index,
-                          0, group_context->common.top->type, upper_port, lower_port, true);
+                          group_context->common.lower_port.port->port_index,
+                          group_context->common.top->type, upper_port, lower_port, true);
   if(!res) {
     return false;
   }
@@ -56,7 +57,8 @@ bool pcie_ide_test_ksetgo_4_setup(void *test_context)
 
 bool test_ksetgo_4_run_phase1(void* doe_context, void* spdm_context, uint32_t* session_id,
                               uint8_t stream_id, uint8_t rp_stream_index,
-                              uint8_t* kcbar_addr, IDE_TEST_TOPOLOGY_TYPE top_type,
+                              uint8_t* kcbar_addr, uint8_t port_index,
+                              IDE_TEST_TOPOLOGY_TYPE top_type,
                               ide_common_test_port_context_t* upper_port,
                               ide_common_test_port_context_t* lower_port,
                               int case_class, int case_id)
@@ -64,17 +66,17 @@ bool test_ksetgo_4_run_phase1(void* doe_context, void* spdm_context, uint32_t* s
   // Now KSetGo
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "KSetGo %s|RX|PR\n", k_set_names[PCI_IDE_KM_KEY_SET_K1]));
   test_ide_km_key_set_go(doe_context, spdm_context, session_id, stream_id,
-                             PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_PR, 0, true, 
+                             PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_PR, port_index, true,
                              "K1|RX|PR", case_class, case_id);
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "KSetGo %s|RX|NPR\n", k_set_names[PCI_IDE_KM_KEY_SET_K1]));
   test_ide_km_key_set_go(doe_context, spdm_context, session_id, stream_id,
-                             PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_NPR, 0, true, 
+                             PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_NPR, port_index, true,
                              "K1|RX|NPR", case_class, case_id);
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "KSetGo %s|RX|CPL\n", k_set_names[PCI_IDE_KM_KEY_SET_K1]));
   test_ide_km_key_set_go(doe_context, spdm_context, session_id, stream_id,
-                             PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_CPL, 0, true, 
+                             PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_CPL, port_index, true,
                              "K1|RX|CPL", case_class, case_id);
 
   // set key_set_select in host ide
@@ -85,17 +87,17 @@ bool test_ksetgo_4_run_phase1(void* doe_context, void* spdm_context, uint32_t* s
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "KSetGo %s|TX|PR\n", k_set_names[PCI_IDE_KM_KEY_SET_K1]));
   test_ide_km_key_set_go(doe_context, spdm_context, session_id, stream_id,
-                             PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_PR, 0, true, 
+                             PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_PR, port_index, true,
                              "K1|TX|PR", case_class, case_id);
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "KSetGo %s|TX|NPR\n", k_set_names[PCI_IDE_KM_KEY_SET_K1]));
   test_ide_km_key_set_go(doe_context, spdm_context, session_id, stream_id,
-                             PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_NPR, 0, true, 
+                             PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_NPR, port_index, true,
                              "K1|TX|NPR", case_class, case_id);
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "KSetGo %s|TX|CPL\n", k_set_names[PCI_IDE_KM_KEY_SET_K1]));
   test_ide_km_key_set_go(doe_context, spdm_context, session_id, stream_id,
-                             PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_CPL, 0, true, 
+                             PCI_IDE_KM_KEY_SET_K1 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_CPL, port_index, true,
                              "K1|TX|CPL", case_class, case_id);
 
   if(teeio_test_case_result(case_class, case_id) != TEEIO_TEST_RESULT_PASS) {
@@ -138,21 +140,22 @@ bool test_ksetgo_4_run_phase1(void* doe_context, void* spdm_context, uint32_t* s
 
 bool test_ksetgo_4_run_phase2(void* doe_context, void* spdm_context, uint32_t* session_id,
                               uint8_t stream_id, uint8_t rp_stream_index, uint8_t ide_id,
-                              uint8_t* kcbar_addr, IDE_TEST_TOPOLOGY_TYPE top_type,
+                              uint8_t* kcbar_addr, uint8_t port_index,
+                              IDE_TEST_TOPOLOGY_TYPE top_type,
                               int case_class, int case_id)
 {
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetGo K0|RX|PR\n"));
   test_ide_km_key_set_go(doe_context, spdm_context, session_id, stream_id,
-                             PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_PR, 0,
+                             PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_PR, port_index,
                              false, "K0|RX|PR", case_class, case_id);
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetGo K0|RX|NPR\n"));
   test_ide_km_key_set_go(doe_context, spdm_context, session_id, stream_id,
-                              PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_NPR, 0,
+                              PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_NPR, port_index,
                               false, "K0|RX|NPR", case_class, case_id);
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetGo K0|RX|CPL\n"));
   test_ide_km_key_set_go(doe_context, spdm_context, session_id, stream_id,
-                             PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_CPL, 0,
+                             PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_RX | PCI_IDE_KM_KEY_SUB_STREAM_CPL, port_index,
                              false, "K0|RX|CPL", case_class, case_id);
 
   // set key_set_select in host ide
@@ -163,17 +166,17 @@ bool test_ksetgo_4_run_phase2(void* doe_context, void* spdm_context, uint32_t* s
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetGo K0|TX|PR\n"));
   test_ide_km_key_set_go(doe_context, spdm_context, session_id, stream_id,
-                             PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_PR, 0,
+                             PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_PR, port_index,
                              false, "K0|TX|PR", case_class, case_id);
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetGo K0|TX|NPR\n"));
   test_ide_km_key_set_go(doe_context, spdm_context, session_id, stream_id,
-                              PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_NPR, 0,
+                              PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_NPR, port_index,
                               false, "K0|TX|NPR", case_class, case_id);
 
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetGo K0|TX|CPL\n"));
   test_ide_km_key_set_go(doe_context, spdm_context, session_id, stream_id,
-                              PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_CPL, 0,
+                              PCI_IDE_KM_KEY_SET_K0 | PCI_IDE_KM_KEY_DIRECTION_TX | PCI_IDE_KM_KEY_SUB_STREAM_CPL, port_index,
                               false, "K0|TX|CPL", case_class, case_id);
 
   if(teeio_test_case_result(case_class, case_id) == TEEIO_TEST_RESULT_PASS) {
@@ -205,6 +208,7 @@ void pcie_ide_test_ksetgo_4_run(void *test_context)
   void *doe_context = group_context->spdm_doe.doe_context;
   void *spdm_context = group_context->spdm_doe.spdm_context;
   uint32_t session_id = group_context->spdm_doe.session_id;
+  uint8_t port_index = group_context->common.lower_port.port->port_index;
 
   ide_common_test_port_context_t* upper_port = &group_context->common.upper_port;
   ide_common_test_port_context_t* lower_port = &group_context->common.lower_port;
@@ -212,7 +216,8 @@ void pcie_ide_test_ksetgo_4_run(void *test_context)
   // phase 1
   res = test_ksetgo_4_run_phase1(doe_context, spdm_context, &session_id,
                                 stream_id, group_context->rp_stream_index,
-                                upper_port->mapped_kcbar_addr, group_context->common.top->type,
+                                upper_port->mapped_kcbar_addr, port_index,
+                                group_context->common.top->type,
                                 upper_port, lower_port,
                                 case_class, case_id);
   if(!res) {
@@ -223,7 +228,7 @@ void pcie_ide_test_ksetgo_4_run(void *test_context)
   res = ide_key_switch_to(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id,
                           &group_context->k_set, group_context->rp_stream_index,
-                          0, group_context->common.top->type, upper_port, lower_port,
+                          port_index, group_context->common.top->type, upper_port, lower_port,
                           PCIE_IDE_STREAM_KS0, true);
   if(!res) {
     goto Done;
@@ -232,7 +237,8 @@ void pcie_ide_test_ksetgo_4_run(void *test_context)
   // phase 2
   res = test_ksetgo_4_run_phase2(doe_context, spdm_context, &session_id,
                                 stream_id, group_context->rp_stream_index, upper_port->ide_id,
-                                upper_port->mapped_kcbar_addr, group_context->common.top->type,
+                                upper_port->mapped_kcbar_addr, port_index,
+                                group_context->common.top->type,
                                 case_class, case_id);
 
 Done:

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_1.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_1.c
@@ -108,7 +108,8 @@ bool pcie_ide_test_ksetstop_1_setup(void *test_context)
   return setup_ide_stream(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id, PCI_IDE_KM_KEY_SET_K0,
                           &group_context->k_set, group_context->rp_stream_index,
-                          0, group_context->common.top->type, upper_port, lower_port, false);
+                          group_context->common.lower_port.port->port_index,
+                          group_context->common.top->type, upper_port, lower_port, false);
 
 }
 
@@ -157,7 +158,7 @@ void pcie_ide_test_ksetstop_1_run(void *test_context)
   uint32_t session_id = group_context->spdm_doe.session_id;
   uint8_t stream_id = group_context->stream_id;
   uint8_t ks = PCI_IDE_KM_KEY_SET_K0;
-  uint8_t port_index = 0;
+  uint8_t port_index = group_context->common.lower_port.port->port_index;
 
   // then test KSetStop  
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetStop %s|RX|PR\n", k_set_names[ks]));

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_2.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_2.c
@@ -39,7 +39,8 @@ bool pcie_ide_test_ksetstop_2_setup(void *test_context)
   return setup_ide_stream(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id, PCI_IDE_KM_KEY_SET_K1,
                           &group_context->k_set, group_context->rp_stream_index,
-                          0, group_context->common.top->type, upper_port, lower_port, false);
+                          group_context->common.lower_port.port->port_index,
+                          group_context->common.top->type, upper_port, lower_port, false);
 
 }
 
@@ -87,7 +88,7 @@ void pcie_ide_test_ksetstop_2_run(void *test_context)
   void* spdm_context = group_context->spdm_doe.spdm_context;
   uint32_t session_id = group_context->spdm_doe.session_id;
   uint8_t stream_id = group_context->stream_id;
-  uint8_t port_index = 0;
+  uint8_t port_index = group_context->common.lower_port.port->port_index;
 
   // then test KSetStop  
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetStop %s|RX|PR\n", k_set_names[PCI_IDE_KM_KEY_SET_K1]));

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_3.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_3.c
@@ -40,7 +40,8 @@ bool pcie_ide_test_ksetstop_3_setup(void *test_context)
   bool res = setup_ide_stream(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id, PCI_IDE_KM_KEY_SET_K0,
                           &group_context->k_set, group_context->rp_stream_index,
-                          0, group_context->common.top->type, upper_port, lower_port, false);
+                          group_context->common.lower_port.port->port_index,
+                          group_context->common.top->type, upper_port, lower_port, false);
   if(!res) {
     return false;
   }
@@ -49,7 +50,8 @@ bool pcie_ide_test_ksetstop_3_setup(void *test_context)
   res = ide_key_switch_to(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id,
                           &group_context->k_set, group_context->rp_stream_index,
-                          0, group_context->common.top->type, upper_port, lower_port, PCIE_IDE_STREAM_KS1, false);
+                          group_context->common.lower_port.port->port_index,
+                          group_context->common.top->type, upper_port, lower_port, PCIE_IDE_STREAM_KS1, false);
 
   return res;
 }
@@ -97,7 +99,7 @@ void pcie_ide_test_ksetstop_3_run(void *test_context)
   void* spdm_context = group_context->spdm_doe.spdm_context;
   uint32_t session_id = group_context->spdm_doe.session_id;
   uint8_t stream_id = group_context->stream_id;
-  uint8_t port_index = 0;
+  uint8_t port_index = group_context->common.lower_port.port->port_index;
 
   // then test KSetStop  
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetStop %s|RX|PR\n", k_set_names[PCI_IDE_KM_KEY_SET_K1]));

--- a/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_4.c
+++ b/teeio-validator/library/pcie_ide_test_lib/test_case/test_case_ksetstop_4.c
@@ -40,7 +40,8 @@ bool pcie_ide_test_ksetstop_4_setup(void *test_context)
   bool res = setup_ide_stream(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id, PCI_IDE_KM_KEY_SET_K1,
                           &group_context->k_set, group_context->rp_stream_index,
-                          0, group_context->common.top->type, upper_port, lower_port, false);
+                          group_context->common.lower_port.port->port_index,
+                          group_context->common.top->type, upper_port, lower_port, false);
   if(!res) {
     return false;
   }
@@ -49,9 +50,8 @@ bool pcie_ide_test_ksetstop_4_setup(void *test_context)
   res = ide_key_switch_to(group_context->spdm_doe.doe_context, group_context->spdm_doe.spdm_context, &group_context->spdm_doe.session_id,
                           upper_port->mapped_kcbar_addr, group_context->stream_id,
                           &group_context->k_set, group_context->rp_stream_index,
-                          0, group_context->common.top->type,
-                          upper_port, lower_port,
-                          PCI_IDE_KM_KEY_SET_K0, false);
+                          group_context->common.lower_port.port->port_index,
+                          group_context->common.top->type, upper_port, lower_port, PCI_IDE_KM_KEY_SET_K0, false);
 
   return res;
 }
@@ -99,7 +99,7 @@ void pcie_ide_test_ksetstop_4_run(void *test_context)
   void* spdm_context = group_context->spdm_doe.spdm_context;
   uint32_t session_id = group_context->spdm_doe.session_id;
   uint8_t stream_id = group_context->stream_id;
-  uint8_t port_index = 0;
+  uint8_t port_index = group_context->common.lower_port.port->port_index;
 
   // then test KSetStop  
   TEEIO_DEBUG((TEEIO_DEBUG_INFO, "[idetest]       Test KSetStop %s|RX|PR\n", k_set_names[PCI_IDE_KM_KEY_SET_K0]));


### PR DESCRIPTION
Fix #312